### PR TITLE
Change from Google Maps to Mapbox maps to display roads/borders over weather radar

### DIFF
--- a/Clock/ApiKeys-example.py
+++ b/Clock/ApiKeys-example.py
@@ -1,5 +1,5 @@
 # change this to your API keys
 # Weather Underground API key
 wuapi = 'YOUR WEATHER UNDERGROUND API KEY'
-# Google Maps API key
-googleapi = ''   # Empty string, optional -- with PiClock, you'll be ok
+# Mapbox API key
+mapboxapi = 'YOUR MAPBOX ACCESS TOKEN'

--- a/Clock/Config-Example-Bedside.py
+++ b/Clock/Config-Example-Bedside.py
@@ -1,17 +1,32 @@
-from GoogleMercatorProjection import LatLng
+from MercatorProjection import LatLng
 from PyQt4.QtGui import QColor
+
 
 # LOCATION(S)
 # Further radar configuration (zoom, marker location)
 #  can be completed under the RADAR section
-primary_coordinates = 44.9764016, -93.2486732  # Change to your Lat/Lon
+primary_coordinates = 25.761680, -80.191790  # Change to your Lat/Lon
+
+# Map layers for radar
+# Sign-in and create custom map styles at https://www.mapbox.com/studio/styles/
+# Example: If static map URL is 
+# https://api.mapbox.com/styles/v1/mapbox/streets-v10/static/-80.2,25.8,10/600x400?access_token=YOUR-ACCESS-TOKEN
+# use the portion between '/styles/v1/' and '/static/'
+# Standard Mapbox maps will look like 'mapbox/streets-v10'
+# User created Mapbox maps will look like 'user-name/map-identifier'
+map_base = 'bcurley/cj712peyz0bwr2sqfndbggupb'  # Mapbox style for land and water only (bottom layer that goes below weather radar)
+map_overlay = 'bcurley/cj712r01c0bw62rm9isme3j8c'  # Mapbox style for labels, roads, borders, and markers only (top layer that goes above weather radar)
+
+# NOAA Weather Radio stream
+# Find mp3 by viewing source of web page at http://noaaweatherradio.org/
+noaastream = 'https://www.weather.gov/media/mfl/nwr/MIAZFPMIA.mp3'
+
+# Weather conditions source from Weather Underground
+wuPWS = 1    # 1 = use Personal Weather Stations (default), 0 = use National Weather Service
 
 wuprefix = 'http://api.wunderground.com/api/'
-# Location for weather report
-wulocation = LatLng(primary_coordinates[0], primary_coordinates[1])
-# Default radar location
-primary_location = LatLng(primary_coordinates[0], primary_coordinates[1])
-noaastream = 'http://audioplayer.wunderground.com:80/tim273/edina'
+wulocation = LatLng(primary_coordinates[0], primary_coordinates[1])  # Location for weather report
+primary_location = LatLng(primary_coordinates[0], primary_coordinates[1])  # Default radar location
 background = 'images/bb.jpg'
 squares1 = 'images/squares1-green.png'
 squares2 = 'images/squares2-green.png'
@@ -22,34 +37,31 @@ hourhand = 'images/hourhand-darkgreen.png'
 minhand = 'images/minhand-darkgreen.png'
 sechand = 'images/sechand-darkgreen.png'
 
-digital = 0             # 1 = Digtal Clock, 0 = Analog Clock
+
+# Clock display
+digital = 0    # 1 = Digtal Clock, 0 = Analog Clock
 
 digitalcolor = "#154018"
-digitalformat = "{0:%I:%M\n%S %p}"  # The format of the time
-digitalsize = 200
+digitalformat = "{0:%I:%M\n%S %p}"  # The format of the digital time on primary screen
+digitalformat2 = "{0:%I:%M:%S %p}"  # The format of the digital time on secondary screen
+digitalsize = 200  # Size of digital time display on primary screen
 # The above example shows in this way:
-#  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v1.jpg
-# ( specifications of the time string are documented here:
-#  https://docs.python.org/2/library/time.html#time.strftime )
+# https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v1.jpg
+# Specifications of the time string are documented here:
+# https://docs.python.org/2/library/time.html#time.strftime
 
 # digitalformat = "{0:%I:%M}"
-# digitalsize = 250
+# digitalformat2 = "{0:%I:%M}"
+# digitalsize = 200
 # The above example shows in this way:
-#  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v2.jpg
+# https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v2.jpg
 
 
-# 0 = English, 1 = Metric
-metric = 0
-
-# minutes
-radar_refresh = 10
-
-# minutes
-weather_refresh = 30
-
+metric = 0  # 0 = English, 1 = Metric
+radar_refresh = 10      # minutes
+weather_refresh = 30    # minutes
 # Wind in degrees instead of cardinal 0 = cardinal, 1 = degrees
 wind_degrees = 0
-
 # Depreciated: use 'satellite' key in radar section, on a per radar basis
 # if this is used, all radar blocks will get satellite images
 satellite = 0
@@ -63,7 +75,7 @@ dimcolor.setAlpha(192)
 
 # Language Specific wording
 # Weather Undeground Language code
-#  (https://www.wunderground.com/weather/api/d/docs?d=language-support&MR=1)
+# https://www.wunderground.com/weather/api/d/docs?d=language-support&MR=1
 wuLanguage = "EN"
 
 # The Python Locale for date/time (locale.setlocale)
@@ -80,19 +92,19 @@ LHumidity = "Humidity "
 LWind = "Wind "
 Lgusting = " gusting "
 LFeelslike = "Feels like "
-LPrecip1hr = " Precip 1hr:"
+LPrecip1hr = " Precip 1hr: "
 LToday = "Today: "
-LSunRise = "Sun Rise:"
+LSunRise = "Sun Rise: "
 LSet = " Set: "
-LMoonPhase = " Moon Phase:"
+LMoonPhase = " Moon Phase: "
 LInsideTemp = "Inside Temp "
 LRain = " Rain: "
 LSnow = " Snow: "
 
 
 # RADAR
-# By default, primary_location entered will be the center and marker of all
-# radar images.
+# By default, primary_location entered will be the
+#  center and marker of all radar images.
 # To update centers/markers, change radar sections below the desired lat/lon as:
 # -FROM-
 # primary_location,
@@ -100,27 +112,32 @@ LSnow = " Snow: "
 # LatLng(44.9764016,-93.2486732),
 radar1 = {
     'center': primary_location,  # the center of your radar block
-    'zoom': 7,  # this is a google maps zoom factor, bigger = smaller area
-    'satellite': 0,  # 1 => show satellite images instead of radar(colorized IR)
-    'markers': (   # google maps markers can be overlayed
+    'zoom': 5,  # map zoom factor, bigger = smaller area
+    'satellite': 0,    # 1 => show satellite images (colorized IR images)
+    'basemap': map_base,  # Mapbox style for land and water only
+    'overlay': map_overlay,  # Mapbox style for labels, roads, borders, and markers only
+    'markers': (   # map markers can be overlayed
         {
             'location': primary_location,
-            'color': 'red',
-            'size': 'small',
+            'shape': 'pin-s',  # Marker shape and size. Options are pin-s, pin-m, pin-l ( '' to hide marker)
+            'symbol': 'home',  # Optional Maki symbol https://www.mapbox.com/maki-icons/ ( '' for default pin symbol)
+            'color': '008',  # Optional 3 or 6 digit hexadecimal color code ( '' for default color)
         },          # dangling comma is on purpose.
     )
 }
 
-
 radar2 = {
     'center': primary_location,
-    'zoom': 11,
+    'zoom': 7,
     'satellite': 0,
+    'basemap': map_base,
+    'overlay': map_overlay,
     'markers': (
         {
             'location': primary_location,
-            'color': 'red',
-            'size': 'small',
+            'shape': 'pin-s',
+            'symbol': 'home',
+            'color': '008',
         },
     )
 }
@@ -130,11 +147,14 @@ radar3 = {
     'center': primary_location,
     'zoom': 7,
     'satellite': 0,
+    'basemap': map_base,
+    'overlay': map_overlay,
     'markers': (
         {
             'location': primary_location,
-            'color': 'red',
-            'size': 'small',
+            'shape': 'pin-s',
+            'symbol': 'home',
+            'color': '008',
         },
     )
 }
@@ -143,11 +163,14 @@ radar4 = {
     'center': primary_location,
     'zoom': 11,
     'satellite': 0,
+    'basemap': map_base,
+    'overlay': map_overlay,
     'markers': (
         {
             'location': primary_location,
-            'color': 'red',
-            'size': 'small',
+            'shape': 'pin-s',
+            'symbol': 'home',
+            'color': '008',
         },
     )
 }

--- a/Clock/Config-Example-Berlin.py
+++ b/Clock/Config-Example-Berlin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from GoogleMercatorProjection import LatLng
+from MercatorProjection import LatLng
 from PyQt4.QtGui import QColor
 
 # LOCATION(S)
@@ -7,10 +7,26 @@ from PyQt4.QtGui import QColor
 # completed under the RADAR section
 primary_coordinates = 52.5074559, 13.144557  # Change to your Lat/Lon
 
-wuprefix = 'http://api.wunderground.com/api/'
-wulocation = LatLng(primary_coordinates[0], primary_coordinates[1])
-primary_location = LatLng(primary_coordinates[0], primary_coordinates[1])
+# Map layers for radar
+# Sign-in and create custom map styles at https://www.mapbox.com/studio/styles/
+# Example: If static map URL is 
+# https://api.mapbox.com/styles/v1/mapbox/streets-v10/static/-80.2,25.8,10/600x400?access_token=YOUR-ACCESS-TOKEN
+# use the portion between '/styles/v1/' and '/static/'
+# Standard Mapbox maps will look like 'mapbox/streets-v10'
+# User created Mapbox maps will look like 'user-name/map-identifier'
+map_base = 'bcurley/cj712peyz0bwr2sqfndbggupb'  # Mapbox style for land and water only (bottom layer that goes below weather radar)
+map_overlay = 'bcurley/cj712r01c0bw62rm9isme3j8c'  # Mapbox style for labels, roads, borders, and markers only (top layer that goes above weather radar)
+
+# NOAA Weather Radio stream
+# Find mp3 by viewing source of web page at http://noaaweatherradio.org/
 noaastream = ''
+
+# Weather conditions source from Weather Underground
+wuPWS = 1    # 1 = use Personal Weather Stations (default), 0 = use National Weather Service
+
+wuprefix = 'http://api.wunderground.com/api/'
+wulocation = LatLng(primary_coordinates[0], primary_coordinates[1])  # Location for weather report
+primary_location = LatLng(primary_coordinates[0], primary_coordinates[1])  # Default radar location
 background = 'images/berlin-at-night-mrwallpaper.jpg'
 squares1 = 'images/squares1-kevin.png'
 squares2 = 'images/squares2-kevin.png'
@@ -22,21 +38,24 @@ minhand = 'images/minhand.png'
 sechand = 'images/sechand.png'
 
 
-digital = 0             # 1 = Digtal Clock, 0 = Analog Clock
+# Clock display
+digital = 0    # 1 = Digtal Clock, 0 = Analog Clock
 
 # Goes with light blue config (like the default one)
 digitalcolor = "#50CBEB"
-digitalformat = "{0:%I:%M\n%S %p}"  # The format of the time
-digitalsize = 200
+digitalformat = "{0:%I:%M\n%S %p}"  # The format of the digital time on primary screen
+digitalformat2 = "{0:%I:%M:%S %p}"  # The format of the digital time on secondary screen
+digitalsize = 200  # Size of digital time display on primary screen
 # The above example shows in this way:
-#  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v1.jpg
-# ( specifications of the time string are documented here:
-#  https://docs.python.org/2/library/time.html#time.strftime )
+# https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v1.jpg
+# Specifications of the time string are documented here:
+# https://docs.python.org/2/library/time.html#time.strftime
 
 # digitalformat = "{0:%I:%M}"
-# digitalsize = 250
-#  The above example shows in this way:
-#  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v2.jpg
+# digitalformat2 = "{0:%I:%M}"
+# digitalsize = 200
+# The above example shows in this way:
+# https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v2.jpg
 
 
 metric = 1  # 0 = English, 1 = Metric
@@ -47,7 +66,6 @@ wind_degrees = 0
 # Depreciated: use 'satellite' key in radar section, on a per radar basis
 # if this is used, all radar blocks will get satellite images
 satellite = 0
-
 
 # gives all text additional attributes using QT style notation
 # example: fontattr = 'font-weight: bold; '
@@ -60,7 +78,7 @@ dimcolor.setAlpha(0)
 
 # Language Specific wording
 # Weather Undeground Language code
-#  (https://www.wunderground.com/weather/api/d/docs?d=language-support&MR=1)
+# https://www.wunderground.com/weather/api/d/docs?d=language-support&MR=1
 wuLanguage = "DL"
 
 # The Python Locale for date/time (locale.setlocale)
@@ -78,11 +96,11 @@ LHumidity = "Feuchtigkeit "
 LWind = "Wind "
 Lgusting = u" böen "
 LFeelslike = u"Gefühlt "
-LPrecip1hr = " Niederschlag 1h:"
+LPrecip1hr = " Niederschlag 1h: "
 LToday = "Heute: "
-LSunRise = "Sonnenaufgang:"
+LSunRise = "Sonnenaufgang: "
 LSet = " unter: "
-LMoonPhase = " Mond Phase:"
+LMoonPhase = " Mond Phase: "
 LInsideTemp = "Innen Temp "
 LRain = " Regen: "
 LSnow = " Schnee: "
@@ -97,27 +115,32 @@ LSnow = " Schnee: "
 # LatLng(44.9764016,-93.2486732),
 radar1 = {
     'center': primary_location,  # the center of your radar block
-    'zoom': 7,  # this is a google maps zoom factor, bigger = smaller area
+    'zoom': 5,  # map zoom factor, bigger = smaller area
     'satellite': 0,    # 1 => show satellite images (colorized IR images)
-    'markers': (   # google maps markers can be overlayed
+    'basemap': map_base,  # Mapbox style for land and water only
+    'overlay': map_overlay,  # Mapbox style for labels, roads, borders, and markers only
+    'markers': (   # map markers can be overlayed
         {
             'location': primary_location,
-            'color': 'red',
-            'size': 'small',
+            'shape': 'pin-s',  # Marker shape and size. Options are pin-s, pin-m, pin-l ( '' to hide marker)
+            'symbol': 'home',  # Optional Maki symbol https://www.mapbox.com/maki-icons/ ( '' for default pin symbol)
+            'color': '008',  # Optional 3 or 6 digit hexadecimal color code ( '' for default color)
         },          # dangling comma is on purpose.
     )
 }
 
-
 radar2 = {
     'center': primary_location,
-    'zoom': 11,
+    'zoom': 7,
     'satellite': 0,
+    'basemap': map_base,
+    'overlay': map_overlay,
     'markers': (
         {
             'location': primary_location,
-            'color': 'red',
-            'size': 'small',
+            'shape': 'pin-s',
+            'symbol': 'home',
+            'color': '008',
         },
     )
 }
@@ -127,11 +150,14 @@ radar3 = {
     'center': primary_location,
     'zoom': 7,
     'satellite': 0,
+    'basemap': map_base,
+    'overlay': map_overlay,
     'markers': (
         {
             'location': primary_location,
-            'color': 'red',
-            'size': 'small',
+            'shape': 'pin-s',
+            'symbol': 'home',
+            'color': '008',
         },
     )
 }
@@ -140,11 +166,14 @@ radar4 = {
     'center': primary_location,
     'zoom': 11,
     'satellite': 0,
+    'basemap': map_base,
+    'overlay': map_overlay,
     'markers': (
         {
             'location': primary_location,
-            'color': 'red',
-            'size': 'small',
+            'shape': 'pin-s',
+            'symbol': 'home',
+            'color': '008',
         },
     )
 }

--- a/Clock/Config-Example-London.py
+++ b/Clock/Config-Example-London.py
@@ -1,4 +1,4 @@
-from GoogleMercatorProjection import LatLng     # NOQA
+from MercatorProjection import LatLng     # NOQA
 from PyQt4.QtGui import QColor
 
 
@@ -7,10 +7,26 @@ from PyQt4.QtGui import QColor
 # completed under the RADAR section
 primary_coordinates = 51.5286416, -0.1015987  # Change to your Lat/Lon
 
+# Map layers for radar
+# Sign-in and create custom map styles at https://www.mapbox.com/studio/styles/
+# Example: If static map URL is 
+# https://api.mapbox.com/styles/v1/mapbox/streets-v10/static/-80.2,25.8,10/600x400?access_token=YOUR-ACCESS-TOKEN
+# use the portion between '/styles/v1/' and '/static/'
+# Standard Mapbox maps will look like 'mapbox/streets-v10'
+# User created Mapbox maps will look like 'user-name/map-identifier'
+map_base = 'bcurley/cj712peyz0bwr2sqfndbggupb'  # Mapbox style for land and water only (bottom layer that goes below weather radar)
+map_overlay = 'bcurley/cj712r01c0bw62rm9isme3j8c'  # Mapbox style for labels, roads, borders, and markers only (top layer that goes above weather radar)
+
+# NOAA Weather Radio stream
+# Find mp3 by viewing source of web page at http://noaaweatherradio.org/
+noaastream = ''
+
+# Weather conditions source from Weather Underground
+wuPWS = 1    # 1 = use Personal Weather Stations (default), 0 = use National Weather Service
+
 wuprefix = 'http://api.wunderground.com/api/'
-wulocation = LatLng(primary_coordinates[0], primary_coordinates[1])
-primary_location = LatLng(primary_coordinates[0], primary_coordinates[1])
-noaastream = '???'
+wulocation = LatLng(primary_coordinates[0], primary_coordinates[1])  # Location for weather report
+primary_location = LatLng(primary_coordinates[0], primary_coordinates[1])  # Default radar location
 background = 'images/london-at-night-wallpapers.jpg'
 squares1 = 'images/squares1-kevin.png'
 squares2 = 'images/squares2-kevin.png'
@@ -22,21 +38,24 @@ minhand = 'images/minhand.png'
 sechand = 'images/sechand.png'
 
 
-digital = 0             # 1 = Digtal Clock, 0 = Analog Clock
+# Clock display
+digital = 0    # 1 = Digtal Clock, 0 = Analog Clock
 
 # Goes with light blue config (like the default one)
 digitalcolor = "#50CBEB"
-digitalformat = "{0:%I:%M\n%S %p}"  # The format of the time
-digitalsize = 200
+digitalformat = "{0:%I:%M\n%S %p}"  # The format of the digital time on primary screen
+digitalformat2 = "{0:%I:%M:%S %p}"  # The format of the digital time on secondary screen
+digitalsize = 200  # Size of digital time display on primary screen
 # The above example shows in this way:
-#  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v1.jpg
-# ( specifications of the time string are documented here:
-#  https://docs.python.org/2/library/time.html#time.strftime )
+# https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v1.jpg
+# Specifications of the time string are documented here:
+# https://docs.python.org/2/library/time.html#time.strftime
 
 # digitalformat = "{0:%I:%M}"
-# digitalsize = 250
-#  The above example shows in this way:
-#  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v2.jpg
+# digitalformat2 = "{0:%I:%M}"
+# digitalsize = 200
+# The above example shows in this way:
+# https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v2.jpg
 
 
 metric = 1  # 0 = English, 1 = Metric
@@ -59,7 +78,7 @@ dimcolor.setAlpha(0)
 
 # Language Specific wording
 # Weather Undeground Language code
-#  (https://www.wunderground.com/weather/api/d/docs?d=language-support&MR=1)
+# https://www.wunderground.com/weather/api/d/docs?d=language-support&MR=1
 wuLanguage = "EN"
 
 # The Python Locale for date/time (locale.setlocale)
@@ -76,11 +95,11 @@ LHumidity = "Humidity "
 LWind = "Wind "
 Lgusting = " gusting "
 LFeelslike = "Feels like "
-LPrecip1hr = " Precip 1hr:"
+LPrecip1hr = " Precip 1hr: "
 LToday = "Today: "
-LSunRise = "Sun Rise:"
+LSunRise = "Sun Rise: "
 LSet = " Set: "
-LMoonPhase = " Moon Phase:"
+LMoonPhase = " Moon Phase: "
 LInsideTemp = "Inside Temp "
 LRain = " Rain: "
 LSnow = " Snow: "
@@ -89,34 +108,39 @@ LSnow = " Snow: "
 # RADAR
 # By default, primary_location entered will be the
 #  center and marker of all radar images.
-# To update centers/markers,change radar sections below the desired lat/lon as:
+# To update centers/markers, change radar sections below the desired lat/lon as:
 # -FROM-
 # primary_location,
 # -TO-
 # LatLng(44.9764016,-93.2486732),
 radar1 = {
     'center': primary_location,  # the center of your radar block
-    'zoom': 7,  # this is a google maps zoom factor, bigger = smaller area
+    'zoom': 5,  # map zoom factor, bigger = smaller area
     'satellite': 0,    # 1 => show satellite images (colorized IR images)
-    'markers': (   # google maps markers can be overlayed
+    'basemap': map_base,  # Mapbox style for land and water only
+    'overlay': map_overlay,  # Mapbox style for labels, roads, borders, and markers only
+    'markers': (   # map markers can be overlayed
         {
             'location': primary_location,
-            'color': 'red',
-            'size': 'small',
+            'shape': 'pin-s',  # Marker shape and size. Options are pin-s, pin-m, pin-l ( '' to hide marker)
+            'symbol': 'home',  # Optional Maki symbol https://www.mapbox.com/maki-icons/ ( '' for default pin symbol)
+            'color': '008',  # Optional 3 or 6 digit hexadecimal color code ( '' for default color)
         },          # dangling comma is on purpose.
     )
 }
 
-
 radar2 = {
     'center': primary_location,
-    'zoom': 11,
+    'zoom': 7,
     'satellite': 0,
+    'basemap': map_base,
+    'overlay': map_overlay,
     'markers': (
         {
             'location': primary_location,
-            'color': 'red',
-            'size': 'small',
+            'shape': 'pin-s',
+            'symbol': 'home',
+            'color': '008',
         },
     )
 }
@@ -126,11 +150,14 @@ radar3 = {
     'center': primary_location,
     'zoom': 7,
     'satellite': 0,
+    'basemap': map_base,
+    'overlay': map_overlay,
     'markers': (
         {
             'location': primary_location,
-            'color': 'red',
-            'size': 'small',
+            'shape': 'pin-s',
+            'symbol': 'home',
+            'color': '008',
         },
     )
 }
@@ -139,11 +166,14 @@ radar4 = {
     'center': primary_location,
     'zoom': 11,
     'satellite': 0,
+    'basemap': map_base,
+    'overlay': map_overlay,
     'markers': (
         {
             'location': primary_location,
-            'color': 'red',
-            'size': 'small',
+            'shape': 'pin-s',
+            'symbol': 'home',
+            'color': '008',
         },
     )
 }

--- a/Clock/Config-Example.py
+++ b/Clock/Config-Example.py
@@ -1,16 +1,32 @@
-from GoogleMercatorProjection import LatLng
+from MercatorProjection import LatLng
 from PyQt4.QtGui import QColor
 
 
 # LOCATION(S)
 # Further radar configuration (zoom, marker location) can be
 # completed under the RADAR section
-primary_coordinates = 44.9764016, -93.2486732  # Change to your Lat/Lon
+primary_coordinates = 25.761680, -80.191790  # Change to your Lat/Lon
+
+# Map layers for radar
+# Sign-in and create custom map styles at https://www.mapbox.com/studio/styles/
+# Example: If static map URL is 
+# https://api.mapbox.com/styles/v1/mapbox/streets-v10/static/-80.2,25.8,10/600x400?access_token=YOUR-ACCESS-TOKEN
+# use the portion between '/styles/v1/' and '/static/'
+# Standard Mapbox maps will look like 'mapbox/streets-v10'
+# User created Mapbox maps will look like 'user-name/map-identifier'
+map_base = 'bcurley/cj712peyz0bwr2sqfndbggupb'  # Mapbox style for land and water only (bottom layer that goes below weather radar)
+map_overlay = 'bcurley/cj712r01c0bw62rm9isme3j8c'  # Mapbox style for labels, roads, borders, and markers only (top layer that goes above weather radar)
+
+# NOAA Weather Radio stream
+# Find mp3 by viewing source of web page at http://noaaweatherradio.org/
+noaastream = 'https://www.weather.gov/media/mfl/nwr/MIAZFPMIA.mp3'
+
+# Weather conditions source from Weather Underground
+wuPWS = 1    # 1 = use Personal Weather Stations (default), 0 = use National Weather Service
 
 wuprefix = 'http://api.wunderground.com/api/'
-wulocation = LatLng(primary_coordinates[0], primary_coordinates[1])
-primary_location = LatLng(primary_coordinates[0], primary_coordinates[1])
-noaastream = 'http://audioplayer.wunderground.com:80/tim273/edina'
+wulocation = LatLng(primary_coordinates[0], primary_coordinates[1])  # Location for weather report
+primary_location = LatLng(primary_coordinates[0], primary_coordinates[1])  # Default radar location
 background = 'images/clockbackground-kevin.png'
 squares1 = 'images/squares1-kevin.png'
 squares2 = 'images/squares2-kevin.png'
@@ -22,21 +38,24 @@ minhand = 'images/minhand.png'
 sechand = 'images/sechand.png'
 
 
-digital = 0             # 1 = Digtal Clock, 0 = Analog Clock
+# Clock display
+digital = 0    # 1 = Digtal Clock, 0 = Analog Clock
 
 # Goes with light blue config (like the default one)
 digitalcolor = "#50CBEB"
-digitalformat = "{0:%I:%M\n%S %p}"  # The format of the time
-digitalsize = 200
+digitalformat = "{0:%I:%M\n%S %p}"  # The format of the digital time on primary screen
+digitalformat2 = "{0:%I:%M:%S %p}"  # The format of the digital time on secondary screen
+digitalsize = 200  # Size of digital time display on primary screen
 # The above example shows in this way:
-#  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v1.jpg
-# ( specifications of the time string are documented here:
-#  https://docs.python.org/2/library/time.html#time.strftime )
+# https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v1.jpg
+# Specifications of the time string are documented here:
+# https://docs.python.org/2/library/time.html#time.strftime
 
 # digitalformat = "{0:%I:%M}"
-# digitalsize = 250
-#  The above example shows in this way:
-#  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v2.jpg
+# digitalformat2 = "{0:%I:%M}"
+# digitalsize = 200
+# The above example shows in this way:
+# https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v2.jpg
 
 
 metric = 0  # 0 = English, 1 = Metric
@@ -59,7 +78,7 @@ dimcolor.setAlpha(0)
 
 # Language Specific wording
 # Weather Undeground Language code
-#  (https://www.wunderground.com/weather/api/d/docs?d=language-support&MR=1)
+# https://www.wunderground.com/weather/api/d/docs?d=language-support&MR=1
 wuLanguage = "EN"
 
 # The Python Locale for date/time (locale.setlocale)
@@ -76,11 +95,11 @@ LHumidity = "Humidity "
 LWind = "Wind "
 Lgusting = " gusting "
 LFeelslike = "Feels like "
-LPrecip1hr = " Precip 1hr:"
+LPrecip1hr = " Precip 1hr: "
 LToday = "Today: "
-LSunRise = "Sun Rise:"
+LSunRise = "Sun Rise: "
 LSet = " Set: "
-LMoonPhase = " Moon Phase:"
+LMoonPhase = " Moon Phase: "
 LInsideTemp = "Inside Temp "
 LRain = " Rain: "
 LSnow = " Snow: "
@@ -96,27 +115,32 @@ LSnow = " Snow: "
 # LatLng(44.9764016,-93.2486732),
 radar1 = {
     'center': primary_location,  # the center of your radar block
-    'zoom': 7,  # this is a google maps zoom factor, bigger = smaller area
+    'zoom': 5,  # map zoom factor, bigger = smaller area
     'satellite': 0,    # 1 => show satellite images (colorized IR images)
-    'markers': (   # google maps markers can be overlayed
+    'basemap': map_base,  # Mapbox style for land and water only
+    'overlay': map_overlay,  # Mapbox style for labels, roads, borders, and markers only
+    'markers': (   # map markers can be overlayed
         {
             'location': primary_location,
-            'color': 'red',
-            'size': 'small',
+            'shape': 'pin-s',  # Marker shape and size. Options are pin-s, pin-m, pin-l ( '' to hide marker)
+            'symbol': 'home',  # Optional Maki symbol https://www.mapbox.com/maki-icons/ ( '' for default pin symbol)
+            'color': '008',  # Optional 3 or 6 digit hexadecimal color code ( '' for default color)
         },          # dangling comma is on purpose.
     )
 }
 
-
 radar2 = {
     'center': primary_location,
-    'zoom': 11,
+    'zoom': 7,
     'satellite': 0,
+    'basemap': map_base,
+    'overlay': map_overlay,
     'markers': (
         {
             'location': primary_location,
-            'color': 'red',
-            'size': 'small',
+            'shape': 'pin-s',
+            'symbol': 'home',
+            'color': '008',
         },
     )
 }
@@ -126,11 +150,14 @@ radar3 = {
     'center': primary_location,
     'zoom': 7,
     'satellite': 0,
+    'basemap': map_base,
+    'overlay': map_overlay,
     'markers': (
         {
             'location': primary_location,
-            'color': 'red',
-            'size': 'small',
+            'shape': 'pin-s',
+            'symbol': 'home',
+            'color': '008',
         },
     )
 }
@@ -139,11 +166,14 @@ radar4 = {
     'center': primary_location,
     'zoom': 11,
     'satellite': 0,
+    'basemap': map_base,
+    'overlay': map_overlay,
     'markers': (
         {
             'location': primary_location,
-            'color': 'red',
-            'size': 'small',
+            'shape': 'pin-s',
+            'symbol': 'home',
+            'color': '008',
         },
     )
 }

--- a/Clock/MercatorProjection.py
+++ b/Clock/MercatorProjection.py
@@ -1,6 +1,7 @@
 # http://stackoverflow.com/questions/12507274/how-to-get-bounds-of-a-google-static-map
 import math
-MERCATOR_RANGE = 256
+#MERCATOR_RANGE = 256  # Use for Google Maps
+MERCATOR_RANGE = 512  # Use for Mapbox
 
 
 def bound(value, opt_min, opt_max):

--- a/Documentation/Install-Clock-Only.md
+++ b/Documentation/Install-Clock-Only.md
@@ -28,41 +28,37 @@ Alternatively, you can download a zip file of the github project.
 https://github.com/n0bel/PiClock/archive/master.zip, then unzip it.
 
 
-### Configure the PiClock api keys
+### Configure the PiClock API keys
 
-The first is to set API keys for Weather Underground and Google Maps.  
+The first is to set API keys for Weather Underground and Mapbox.  
 These are both free, unless you have large volume.
-The PiClock usage is well below the maximums  imposed by the free api keys.
+The PiClock usage is well below the maximums imposed by the free API keys.
 
-Weather Underground api keys are created at this link: 
-http://www.wunderground.com/weather/api/ Here too, it'll ask you for an
-Application (maybe PiClock?) that you're using the api key with.
+Weather Underground API keys are created at this link: 
+http://www.wunderground.com/weather/api/ Here, it'll ask you for a
+project name (maybe PiClock?) with which you're using the API key.
 
-A _Google Maps api key is not required_, unless you pull a large volume of maps.
-This *can* occur if you're continually pulling maps because you're restarting
-the clock often durning development.   The maps are pulled once at the start.
+Mapbox API keys, or access tokens, are created at this link: 
+https://www.mapbox.com/studio/account/tokens/ Here too, it'll ask you for a
+project name (maybe PiClock?) with which you're using the API key.
 
-If you want a key, this is how its done. Google Maps api keys are created at this link:
-https://console.developers.google.com/flows/enableapi?apiid=maps_backend&keyType=CLIENT_SIDE
-You'll require a google user and password.  After that it'll require
-you create a "project" (maybe PiClock for a project name?)
-It will also ask about Client Ids, which you can skip (just clock ok/create)
 
-Now that you have your api keys...
+
+Now that you have your API keys...
 
 ```
 cd PiClock
 cd Clock
 cp ApiKeys-example.py ApiKeys.py
-[use your favorite editor] ApiKeys.py
+nano ApiKeys.py
 ```
-Put your api keys in the file as indicated
+Put your API keys in the file as indicated
 ```
 #change this to your API keys
 # Weather Underground API key
 wuapi = 'YOUR WEATHER UNDERGROUND API KEY'
-# Google Maps API key
-googleapi = ''  #Empty string, the key is optional -- if you pull a small volume, you'll be ok
+# Mapbox API key
+mapboxapi = 'YOUR MAPBOX ACCESS TOKEN'
 ```
 
 ### Configure your PiClock
@@ -85,7 +81,7 @@ care not to disturb the format while changing the data.
 The first thing is to change the Latitudes and Longitudes you see to yours.
 They occur in several places. The first one in the file is where your weather
 forecast comes from.   The others are where your radar images are centered
-and where the markers appear on those images.  Markers are those little red
+and where the markers appear on those images.  Markers are those little blue
 location pointers.
 
 ### Run it!

--- a/Documentation/Install-Wheezy.md
+++ b/Documentation/Install-Wheezy.md
@@ -239,29 +239,23 @@ sudo reboot
 ```
 
 
-### Configure the PiClock api keys
+### Configure the PiClock API keys
 
-The first is to set API keys for Weather Underground and Google Maps.  
+The first is to set API keys for Weather Underground and Mapbox.  
 These are both free, unless you have large volume.
-The PiClock usage is well below the maximums  imposed by the free api keys.
+The PiClock usage is well below the maximums imposed by the free API keys.
 
-Weather Underground api keys are created at this link: 
-http://www.wunderground.com/weather/api/ Here too, it'll ask you for an
-Application (maybe PiClock?) that you're using the api key with.
+Weather Underground API keys are created at this link: 
+http://www.wunderground.com/weather/api/ Here, it'll ask you for a
+project name (maybe PiClock?) with which you're using the API key.
 
-A _Google Maps api key is not required_, unless you pull a large volume of maps.
-This *can* occur if you're continually pulling maps because you're restarting
-the clock often durning development.   The maps are pulled once at the start.
-
-If you want a key, this is how its done. Google Maps api keys are created at this link:
-https://console.developers.google.com/flows/enableapi?apiid=maps_backend&keyType=CLIENT_SIDE
-You'll require a google user and password.  After that it'll require
-you create a "project" (maybe PiClock for a project name?)
-It will also ask about Client Ids, which you can skip (just clock ok/create)
+Mapbox API keys, or access tokens, are created at this link: 
+https://www.mapbox.com/studio/account/tokens/ Here too, it'll ask you for a
+project name (maybe PiClock?) with which you're using the API key.
 
 
 
-Now that you have your api keys...
+Now that you have your API keys...
 
 ```
 cd PiClock
@@ -269,13 +263,13 @@ cd Clock
 cp ApiKeys-example.py ApiKeys.py
 nano ApiKeys.py
 ```
-Put your api keys in the file as indicated
+Put your API keys in the file as indicated
 ```
 #change this to your API keys
 # Weather Underground API key
 wuapi = 'YOUR WEATHER UNDERGROUND API KEY'
-# Google Maps API key
-googleapi = ''  #Empty string, the key is optional -- if you pull a small volume, you'll be ok
+# Mapbox API key
+mapboxapi = 'YOUR MAPBOX ACCESS TOKEN'
 ```
 
 ### Configure your PiClock
@@ -298,7 +292,7 @@ care not to disturb the format while changing the data.
 The first thing is to change the Latitudes and Longitudes you see to yours.
 They occur in several places. The first one in the file is where your weather
 forecast comes from.   The others are where your radar images are centered
-and where the markers appear on those images.  Markers are those little red
+and where the markers appear on those images.  Markers are those little blue
 location pointers.
 
 The second thing to change is your NOAA weather radio stream url.  You can

--- a/Documentation/Install.md
+++ b/Documentation/Install.md
@@ -245,34 +245,23 @@ sudo reboot
 ```
 
 
-### Configure the PiClock api keys
+### Configure the PiClock API keys
 
-The first is to set API keys for Weather Underground and Google Maps.  
+The first is to set API keys for Weather Underground and Mapbox.  
 These are both free, unless you have large volume.
-The PiClock usage is well below the maximums  imposed by the free api keys.
+The PiClock usage is well below the maximums imposed by the free API keys.
 
-Weather Underground api keys are created at this link: 
-http://www.wunderground.com/weather/api/ Here too, it'll ask you for an
-Application (maybe PiClock?) that you're using the api key with.
+Weather Underground API keys are created at this link: 
+http://www.wunderground.com/weather/api/ Here, it'll ask you for a
+project name (maybe PiClock?) with which you're using the API key.
 
-## Optional Google Maps API key
-
-A Google Maps api key is _not required_, unless you pull a large volume of maps.
-Most everyone can leave this key empty.  
-
-You only need a key if you're continually pulling maps because you're restarting
-the clock often durning development.   The maps are pulled once at the start.
-
-If you want a key, this is how its done. Google Maps api keys are created at this link:
-https://console.developers.google.com/flows/enableapi?apiid=maps_backend&keyType=CLIENT_SIDE
-You'll require a google user and password.  After that it'll require
-you create a "project" (maybe PiClock for a project name?)
-It will also ask about Client Ids, which you can skip (just clock ok/create).  You need to 
-then activate the key.
+Mapbox API keys, or access tokens, are created at this link: 
+https://www.mapbox.com/studio/account/tokens/ Here too, it'll ask you for a
+project name (maybe PiClock?) with which you're using the API key.
 
 
 
-Now that you have your api keys...
+Now that you have your API keys...
 
 ```
 cd PiClock
@@ -280,13 +269,13 @@ cd Clock
 cp ApiKeys-example.py ApiKeys.py
 nano ApiKeys.py
 ```
-Put your api keys in the file as indicated
+Put your API keys in the file as indicated
 ```
 #change this to your API keys
 # Weather Underground API key
 wuapi = 'YOUR WEATHER UNDERGROUND API KEY'
-# Google Maps API key
-googleapi = ''  #Empty string, the key is optional -- if you pull a small volume, you'll be ok
+# Mapbox API key
+mapboxapi = 'YOUR MAPBOX ACCESS TOKEN'
 ```
 
 ### Configure your PiClock
@@ -309,7 +298,7 @@ care not to disturb the format while changing the data.
 The first thing is to change the primary_coordinates to yours.  That is really
 all that is manditory.  Further customization of the radar maps can be done in
 the Radar section.  There you can customize where your radar images are centered
-and where the markers appear on those images.  Markers are those little red
+and where the markers appear on those images.  Markers are those little blue
 location pointers.  Radar1 and 2 show on the first page, and 3 and 4 show on the
 second page of the display (here's a post of about that:
 https://www.facebook.com/permalink.php?story_fbid=1371576642857593&id=946361588712436&substory_index=0 )

--- a/Documentation/Overview.md
+++ b/Documentation/Overview.md
@@ -9,10 +9,10 @@ the composite output as well, but this is not a design goal.  The main
 program (Clock/PyQtPiClock.py) will also run on Windows, Mac, and Linux,
 as long as python 2.7+ and PyQt4 is installed.
 
-The Weather data comes from Weather Underground using their API 
+The weather data comes from Weather Underground using their API 
 ( http://www.wunderground.com/weather/api/ ).   The maps are from
-Google Maps API.   **You must get an API Key from weather
-underground in order to make this work.**  It is free for low
+Mapbox API.   **You must get an API Key from Weather
+Underground and Mapbox in order to make this work.**  It is free for low
 usage such as this application.
 
 The PiClock can be customized with several supported additional things:


### PR DESCRIPTION
Regarding Issue  #81:  Made changes to PiClock so that it uses customized maps from Mapbox (OpenStreetMap) instead of Google Maps.  In doing so, utilized a bottom map layer of land and water only, then the weather radar layer, and then a top transparent layer of labels, roads, borders, and markers only.  I created the map layers myself, using the free [Mapbox Studio](https://www.mapbox.com/mapbox-studio/).  Further details and tweaks listed in the commit descriptions.

Known Issue: 
Timestamp for animated weather radar can be partially obscured by the Mapbox overlay layer (labels, roads, borders).  No easy method for creating additional Weather Underground layer to go on top with hidden radar but visible timestamp.