### PR TITLE
Tiny typo in install.md

### DIFF
--- a/Documentation/Install.md
+++ b/Documentation/Install.md
@@ -482,7 +482,7 @@ Backup your changes first!
 
 Also, if you're using gpio-keys, you may need to remake it:
 ```
-cd PiClock/Buttons
+cd PiClock/Button
 rm gpio-keys
 make gpio-keys
 ```


### PR DESCRIPTION
Was re-reading install instructions for the noa stream  for #134  and spotted this.