### PR TITLE
Fix #122 #141 and part of #125

### DIFF
--- a/Clock/Config-Example.py
+++ b/Clock/Config-Example.py
@@ -36,8 +36,9 @@ digital = 0             # 1 = Digtal Clock, 0 = Analog Clock
 
 # Goes with light blue config (like the default one)
 digitalcolor = "#50CBEB"
-digitalformat = "{0:%I:%M\n%S %p}"  # Format digital time on primary screen
+digitalformat = "{0:%I:%M\n%S %p}"  # Format of the digital clock face
 digitalsize = 200
+
 # The above example shows in this way:
 #  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v1.jpg
 # ( specifications of the time string are documented here:
@@ -48,27 +49,71 @@ digitalsize = 200
 #  The above example shows in this way:
 #  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v2.jpg
 
-digitalformat2 = "{0:%H:%M:%S}"  # Format for digital time on second screen
+digitalformat2 = "{0:%H:%M:%S}"  # Format of the digital time on second screen
 
 # Non digital date and time formats
 
-# Date time format primary screen:
-# Locale full dayname and monthname, day of month number{th/rd} full year:
+# For Date/Time format directives for python2 see the table at the bottom in: 
+# https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior
+#
+# For python3 doc see:
+# https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior
+
+#     The strings "0:" and "0." refer to the relevant date-time variable
+# Some of them as used here:
+# %A - Weekday as locale’s full name
+# %a - same as %A but abbreviated
+
+# %B - Month as locale’s full name.
+# %b - same as %B but abbreviated
+
+# %H - 24 hour clock
+# %I - 12 hour clock
+# %M - minutes 
+# %p - AM/PM
+# 
+# Date / time format of the digital clock face:
+#     %A   - locale name of weekday
+#     %B   - Month as locale’s full name
+#     day  - Day of the month as a zero-padded decimal number
+#               the {1} adds suffix th or rd
+#     year - 4 num year
+#     Local full dayname and monthname, day of month number{th/rd} year
 LtopDateformat = '{0:%A %B} {0.day}<sup>{1}</sup> {0.year}'
+
 # Date time format second screen:
-# Locale abbreviated day- and monthname, day of month number{th/rd} full year:
+#     Local abbreviated day- and monthname, day of month number{th/rd} year
+#     Same explanation as LtopDateformat only abbreciated
 LtopDateformat2 = "{0:%a %b} {0.day}<sup>{1}</sup> {0.year}"
-# the default 12hour clock AM/PM = Time under the top-left weather conditions:
+
+#     European example might be:
+#     %A   - locale name of weekday
+#     %-d  - day of month no leading zero 
+#     %B   - Month as locale’s full name
+#     year - 4 num year: 
+# LtopDateformat = '{0:%A %-d}{1} {0:%B} {0.year}'
+# and using %a and %b for abbreviated on the second screen:
+# LtopDateformat2 = '{0:%a %-d}{1} {0:%b} {0.year}'
+
+
+# Format for Time under the top-left weather conditions
 Ltimeformat = "{0:%I:%M %p}"
-# the default 12hour clock AM/PM = Time Sun-up/down:
+
+# Format for Time Sun-up/down:
 Ltimesunformat = "{0:%I:%M %p}"
-# 24-hour hour and minute = Timestamp of Rainview forecast:
+
+# Format for Timestamp in Rainview radar images:
 Ltimestampformat = '{0:%H:%M}'
+
+# Format for day/time in forcast boxes on the right:
+#     the first three forecast boxes:
 Lforecastdaytimeformat = '{0:%I:%M %p}'
+#     the bottom forecast boxes:
 Lforecastdayformat = "{0:%A}"
 
 usemapbox = 0   # Use Mapbox.com for maps, needs api key (mbapi in ApiKeys.py)
 metric = 0  # 0 = English, 1 = Metric
+
 radar_refresh = 10      # minutes
 radarIMGinterval = 200  # interval between each frame of animations in msec
 radarSETinterval = 5    # interval between animations (n * radarIMGinterval)

--- a/Clock/Config-Example.py
+++ b/Clock/Config-Example.py
@@ -1,3 +1,9 @@
+# -*- coding: utf-8 -*-
+
+"""
+     Configuration module for PyQt clock
+"""
+
 from GoogleMercatorProjection import LatLng
 from PyQt4.QtGui import QColor
 
@@ -20,13 +26,19 @@ hourhand = 'images/hourhand.png'
 minhand = 'images/minhand.png'
 sechand = 'images/sechand.png'
 
+# SlideShow
+useslideshow = 0             # 1 to enable, 0 to disable
+slide_time = 305              # in seconds, 3600 per hour
+slides = 'images/slideshow'   # the path to your local images
+slide_bg_color = "#000"       # https://htmlcolorcodes.com/  black #000
 
 digital = 0             # 1 = Digtal Clock, 0 = Analog Clock
 
 # Goes with light blue config (like the default one)
 digitalcolor = "#50CBEB"
-digitalformat = "{0:%I:%M\n%S %p}"  # The format of the time
+digitalformat = "{0:%I:%M\n%S %p}"  # Format of the digital clock face
 digitalsize = 200
+
 # The above example shows in this way:
 #  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v1.jpg
 # ( specifications of the time string are documented here:
@@ -37,15 +49,17 @@ digitalsize = 200
 #  The above example shows in this way:
 #  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v2.jpg
 
+digitalformat2 = "{0:%H:%M:%S}"  # Format of the digital time on second screen
 
+usemapbox = 0   # Use Mapbox.com for maps, needs api key (mbapi in ApiKeys.py)
 metric = 0  # 0 = English, 1 = Metric
 radar_refresh = 10      # minutes
+radarIMGinterval = 200  # interval between each frame of the animations in milliseconds
+radarSETinterval = 5    # interval between animations (n times radarIMGinterval)
+
 weather_refresh = 30    # minutes
 # Wind in degrees instead of cardinal 0 = cardinal, 1 = degrees
 wind_degrees = 0
-# Depreciated: use 'satellite' key in radar section, on a per radar basis
-# if this is used, all radar blocks will get satellite images
-satellite = 0
 
 # gives all text additional attributes using QT style notation
 # example: fontattr = 'font-weight: bold; '
@@ -73,35 +87,49 @@ DateLocale = ''
 LPressure = "Pressure "
 LHumidity = "Humidity "
 LWind = "Wind "
-Lgusting = " gusting "
+Lgusting = " gust "
 LFeelslike = "Feels like "
-LPrecip1hr = " Precip 1hr:"
+LPrecip1hr = " Precip 1hr: "
 LToday = "Today: "
-LSunRise = "Sun Rise:"
+LSunRise = "Sun Rise: "
 LSet = " Set: "
-LMoonPhase = " Moon Phase:"
+LMoonPhase = " Moon: "
 LInsideTemp = "Inside Temp "
 LRain = " Rain: "
 LSnow = " Snow: "
-
+Lmoon1 = 'New Moon'
+Lmoon2 = 'Waxing Crescent'
+Lmoon3 = 'First Quarter'
+Lmoon4 = 'Waxing Gibbous'
+Lmoon5 = 'Full Moon'
+Lmoon6 = 'Waning Gibbous'
+Lmoon7 = 'Third Quarter'
+Lmoon8 = 'Waning Crecent'
 
 # RADAR
 # By default, primary_location entered will be the
 #  center and marker of all radar images.
-# To update centers/markers, change radar sections below the desired lat/lon as:
-# -FROM-
-# primary_location,
-# -TO-
-# LatLng(44.9764016,-93.2486732),
+# To update centers/markers, change radar sections
+# below the desired lat/lon as:
+#    -FROM-
+#    primary_location,
+#    -TO-
+#    LatLng(44.9764016,-93.2486732),
 radar1 = {
     'center': primary_location,  # the center of your radar block
-    'zoom': 7,  # this is a google maps zoom factor, bigger = smaller area
-    'satellite': 0,    # 1 => show satellite images (colorized IR images)
+    'zoom': 7,  # this is a maps zoom factor, bigger = smaller area
+    'style': 'mapbox/satellite-streets-v10',  # optional style (mapbox only)
+    'color': 6,  # rainviewer radar color style:
+                 # https://www.rainviewer.com/api.html#colorSchemes
+    'smooth': 1,  # rainviewer radar smoothing
+    'snow': 1,  # rainviewer radar show snow as different color
     'markers': (   # google maps markers can be overlayed
         {
+            'visible': 1, # 0 = hide marker, 1 = show marker
             'location': primary_location,
             'color': 'red',
             'size': 'small',
+            'image': 'teardrop-dot',  # optional image from the markers folder
         },          # dangling comma is on purpose.
     )
 }
@@ -110,12 +138,17 @@ radar1 = {
 radar2 = {
     'center': primary_location,
     'zoom': 11,
-    'satellite': 0,
+    'style': 'mapbox/satellite-streets-v10',
+    'color': 6, 
+    'smooth': 1,
+    'snow': 1,
     'markers': (
         {
+            'visible': 1,
             'location': primary_location,
             'color': 'red',
             'size': 'small',
+            'image': 'teardrop-dot',
         },
     )
 }
@@ -124,12 +157,17 @@ radar2 = {
 radar3 = {
     'center': primary_location,
     'zoom': 7,
-    'satellite': 0,
+    'style': 'mapbox/satellite-streets-v10',
+    'color': 6, 
+    'smooth': 1,
+    'snow': 1,
     'markers': (
         {
+            'visible': 1,
             'location': primary_location,
             'color': 'red',
             'size': 'small',
+            'image': 'teardrop-dot',
         },
     )
 }
@@ -137,12 +175,17 @@ radar3 = {
 radar4 = {
     'center': primary_location,
     'zoom': 11,
-    'satellite': 0,
+    'style': 'mapbox/satellite-streets-v10',
+    'color': 6, 
+    'smooth': 1,
+    'snow': 1,
     'markers': (
         {
+            'visible': 1,
             'location': primary_location,
             'color': 'red',
             'size': 'small',
+            'image': 'teardrop-dot',
         },
     )
 }

--- a/Clock/Config-Example.py
+++ b/Clock/Config-Example.py
@@ -36,9 +36,8 @@ digital = 0             # 1 = Digtal Clock, 0 = Analog Clock
 
 # Goes with light blue config (like the default one)
 digitalcolor = "#50CBEB"
-digitalformat = "{0:%I:%M\n%S %p}"  # Format of the digital clock face
+digitalformat = "{0:%I:%M\n%S %p}"  # Format digital time on primary screen
 digitalsize = 200
-
 # The above example shows in this way:
 #  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v1.jpg
 # ( specifications of the time string are documented here:
@@ -49,13 +48,30 @@ digitalsize = 200
 #  The above example shows in this way:
 #  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v2.jpg
 
-digitalformat2 = "{0:%H:%M:%S}"  # Format of the digital time on second screen
+digitalformat2 = "{0:%H:%M:%S}"  # Format for digital time on second screen
+
+# Non digital date and time formats
+
+# Date time format primary screen:
+# Locale full dayname and monthname, day of month number{th/rd} full year:
+LtopDateformat = '{0:%A %B} {0.day}<sup>{1}</sup> {0.year}'
+# Date time format second screen:
+# Locale abbreviated day- and monthname, day of month number{th/rd} full year:
+LtopDateformat2 = "{0:%a %b} {0.day}<sup>{1}</sup> {0.year}"
+# the default 12hour clock AM/PM = Time under the top-left weather conditions:
+Ltimeformat = "{0:%I:%M %p}"
+# the default 12hour clock AM/PM = Time Sun-up/down:
+Ltimesunformat = "{0:%I:%M %p}"
+# 24-hour hour and minute = Timestamp of Rainview forecast:
+Ltimestampformat = '{0:%H:%M}'
+Lforecastdaytimeformat = '{0:%I:%M %p}'
+Lforecastdayformat = "{0:%A}"
 
 usemapbox = 0   # Use Mapbox.com for maps, needs api key (mbapi in ApiKeys.py)
 metric = 0  # 0 = English, 1 = Metric
 radar_refresh = 10      # minutes
-radarIMGinterval = 200  # interval between each frame of the animations in milliseconds
-radarSETinterval = 5    # interval between animations (n times radarIMGinterval)
+radarIMGinterval = 200  # interval between each frame of animations in msec
+radarSETinterval = 5    # interval between animations (n * radarIMGinterval)
 
 weather_refresh = 30    # minutes
 # Wind in degrees instead of cardinal 0 = cardinal, 1 = degrees
@@ -109,8 +125,8 @@ Lmoon8 = 'Waning Crecent'
 # RADAR
 # By default, primary_location entered will be the
 #  center and marker of all radar images.
-# To update centers/markers, change radar sections
-# below the desired lat/lon as:
+# To update centers/markers,
+#    change radar sections below the desired lat/lon as:
 #    -FROM-
 #    primary_location,
 #    -TO-
@@ -125,7 +141,7 @@ radar1 = {
     'snow': 1,  # rainviewer radar show snow as different color
     'markers': (   # google maps markers can be overlayed
         {
-            'visible': 1, # 0 = hide marker, 1 = show marker
+            'visible': 1,  # 0 = hide marker, 1 = show marker
             'location': primary_location,
             'color': 'red',
             'size': 'small',
@@ -139,7 +155,7 @@ radar2 = {
     'center': primary_location,
     'zoom': 11,
     'style': 'mapbox/satellite-streets-v10',
-    'color': 6, 
+    'color': 6,
     'smooth': 1,
     'snow': 1,
     'markers': (
@@ -158,7 +174,7 @@ radar3 = {
     'center': primary_location,
     'zoom': 7,
     'style': 'mapbox/satellite-streets-v10',
-    'color': 6, 
+    'color': 6,
     'smooth': 1,
     'snow': 1,
     'markers': (
@@ -176,7 +192,7 @@ radar4 = {
     'center': primary_location,
     'zoom': 11,
     'style': 'mapbox/satellite-streets-v10',
-    'color': 6, 
+    'color': 6,
     'smooth': 1,
     'snow': 1,
     'markers': (

--- a/Clock/PyQtPiClock.py
+++ b/Clock/PyQtPiClock.py
@@ -9,8 +9,6 @@ import time
 import json
 import locale
 import random
-# import urllib
-# import re
 
 from PyQt4 import QtGui, QtCore, QtNetwork
 from PyQt4.QtGui import QPixmap, QBrush, QColor
@@ -33,11 +31,11 @@ def tick():
     global clockrect
     global datex, datex2, datey2, pdy
 
-    if Config.DateLocale != "":
-        try:
-            locale.setlocale(locale.LC_TIME, Config.DateLocale)
-        except:
-            pass
+    # if Config.DateLocale != "":  # Too many times and not needed HERE
+    #     try:
+    #         locale.setlocale(locale.LC_TIME, Config.DateLocale)
+    #     except:
+    #         pass
 
     now = datetime.datetime.now()
     if Config.digital:
@@ -124,8 +122,10 @@ def tick():
             sup = 'rd'
         if Config.DateLocale != "":
             sup = ""
-        ds = "{0:%A %B} {0.day}<sup>{1}</sup> {0.year}".format(now, sup)
-        ds2 = "{0:%a %b} {0.day}<sup>{1}</sup> {0.year}".format(now, sup)
+        ds = Config.LtopDateformat.format(now, sup)
+        ds = ds.decode('utf-8')
+        ds2 = Config.LtopDateformat2.format(now, sup)
+        ds2 = ds2.decode('utf-8')
         datex.setText(ds)
         datex2.setText(ds2)
 
@@ -159,19 +159,19 @@ def tempfinished():
 
 
 def tempm(f):
-        return (f - 32) / 1.8
+    return (f - 32) / 1.8
 
 
 def speedm(f):
-        return f * 0.621371192
+    return f * 0.621371192
 
 
 def pressi(f):
-        return f * 0.029530
+    return f * 0.029530
 
 
 def heightm(f):
-        return f * 25.4
+    return f * 25.4
 
 
 def phase(f):
@@ -231,7 +231,6 @@ def wxfinished():
     global wxreply, wxdata
     global wxicon, temper, wxdesc, press, humidity
     global wind, wind2, wdate, bottom, forecast
-    #  duplicate wxdesc into wxdesc2:
     global wxicon2, temper2, wxdesc2, attribution
 
     attribution.setText("DarkSky.net")
@@ -267,8 +266,9 @@ def wxfinished():
                      '%.1f' % (speedm(f['windGust'])) + 'kmh')
         wind2.setText(Config.LFeelslike +
                       '%.1f' % (tempm(f['apparentTemperature'])) + u'°C')
-        wdate.setText("{0:%H:%M}".format(datetime.datetime.fromtimestamp(
-            int(f['time']))))
+        wdate.setText(Config.Ltimeformat.format(
+            datetime.datetime.fromtimestamp(
+                int(f['time']))))
 # Config.LPrecip1hr + f['precip_1hr_metric'] + 'mm ' +
 # Config.LToday + f['precip_today_metric'] + 'mm')
     else:
@@ -286,7 +286,8 @@ def wxfinished():
                      '%.1f' % (f['windGust']) + 'mph')
         wind2.setText(Config.LFeelslike +
                       '%.1f' % (f['apparentTemperature']) + u'°F')
-        wdate.setText("{0:%H:%M}".format(datetime.datetime.fromtimestamp(
+        wdate.setText(Config.Ltimeformat.format(
+            datetime.datetime.fromtimestamp(
                 int(f['time']))))
 # Config.LPrecip1hr + f['precip_1hr_in'] + 'in ' +
 # Config.LToday + f['precip_today_in'] + 'in')
@@ -294,11 +295,13 @@ def wxfinished():
     bottomText = ""
     if "sunriseTime" in wxdata["daily"]["data"][0]:
         bottomText += (Config.LSunRise +
-                       "{0:%H:%M}".format(datetime.datetime.fromtimestamp(
-                        wxdata["daily"]["data"][0]["sunriseTime"])) +
+                       Config.Ltimesunformat.format(
+                           datetime.datetime.fromtimestamp(
+                               wxdata["daily"]["data"][0]["sunriseTime"])) +
                        Config.LSet +
-                       "{0:%H:%M}".format(datetime.datetime.fromtimestamp(
-                        wxdata["daily"]["data"][0]["sunsetTime"])))
+                       Config.Ltimesunformat.format(
+                           datetime.datetime.fromtimestamp(
+                               wxdata["daily"]["data"][0]["sunsetTime"])))
 
     if "moonPhase" in wxdata["daily"]["data"][0]:
         bottomText += (Config.LMoonPhase +
@@ -319,8 +322,8 @@ def wxfinished():
             Qt.SmoothTransformation))
         wx = fl.findChild(QtGui.QLabel, "wx")
         day = fl.findChild(QtGui.QLabel, "day")
-        day.setText("{0:%A %I:%M%p}".format(datetime.datetime.fromtimestamp(
-            int(f['time']))))
+        day.setText(Config.Lforecastdaytimeformat.format(
+            datetime.datetime.fromtimestamp(int(f['time']))).decode('utf-8'))
         s = ''
         pop = 0
         ptype = ''
@@ -366,8 +369,8 @@ def wxfinished():
             Qt.SmoothTransformation))
         wx = fl.findChild(QtGui.QLabel, "wx")
         day = fl.findChild(QtGui.QLabel, "day")
-        day.setText("{0:%A}".format(datetime.datetime.fromtimestamp(
-            int(f['time']))))
+        day.setText(Config.Lforecastdayformat.format(
+            datetime.datetime.fromtimestamp(int(f['time']))).decode('utf-8'))
         s = ''
         pop = 0
         ptype = ''
@@ -600,7 +603,7 @@ class Radar(QtGui.QLabel):
             self.totalHeight += 256
             self.tilesHeight += 1
             for x in range(int(self.cornerTiles["NW"]["X"]),
-                           int(self.cornerTiles["NE"]["X"]) + 1):
+                           int(self.cornerTiles["NE"]["X"])+1):
                 tile = {"X": x, "Y": y}
                 self.tiles.append(tile)
                 if 'color' not in radar:
@@ -636,9 +639,7 @@ class Radar(QtGui.QLabel):
             return
         if self.displayedFrame == 0:
             self.ticker += 1
-            # /BL #137 # The time between each frame SET is n times larger 
-            #            than time between each frame
-            if self.ticker < Config.radarSETinterval:
+            if self.ticker < 5:
                 return
         self.ticker = 0
         f = self.frameImages[self.displayedFrame]
@@ -727,9 +728,9 @@ class Radar(QtGui.QLabel):
         ii = None
         painter2 = QPainter()
         painter2.begin(ii2)
-        # typo rainvewer rainviewer:
-        timestamp = "{0:%H:%M} rainviewer.com".format(
+        timestamp = Config.Ltimestampformat.format(
                     datetime.datetime.fromtimestamp(self.getTime))
+        timestamp = timestamp + " RainViewer"
         painter2.setPen(QColor(63, 63, 63, 255))
         painter2.setFont(QFont("Arial", 8))
         painter2.setRenderHint(QPainter.TextAntialiasing)
@@ -749,7 +750,7 @@ class Radar(QtGui.QLabel):
         mb = 0
         try:
             mb = Config.usemapbox
-        except:
+        except AttributeError:
             pass
         if mb:
             return self.mapboxurl(radar, rect)
@@ -869,7 +870,7 @@ class Radar(QtGui.QLabel):
 
     def wxstart(self):
         print "wxstart for " + self.myname
-        self.timer.start(Config.radarIMGinterval)
+        self.timer.start(200)
 
     def wxstop(self):
         print "wxstop for " + self.myname
@@ -979,7 +980,22 @@ if not os.path.isfile(configname + ".py"):
 
 Config = __import__(configname)
 
-# define default values for new/optional config variables.
+
+try:
+    Config.DateLocale
+except AttributeError:
+    Config.DateLocale = ""
+    print("Warn: take default Config.DateLocale:             \t'%s'"
+          % Config.DateLocale)
+
+if Config.DateLocale != "":
+    try:
+        locale.setlocale(locale.LC_TIME, Config.DateLocale)
+    except Exception as e:
+        print("Error: (setlocale.LC_TIME, '%s') fails, reason: %s"
+              % (Config.DateLocale, e))
+        Config.DateLocale = ""
+        pass
 
 try:
     Config.location
@@ -1000,20 +1016,6 @@ try:
     Config.radar_refresh
 except AttributeError:
     Config.radar_refresh = 10    # minutes
-
-try:
-    Config.radarIMGinterval
-except AttributeError:
-    Config.radarIMGinterval = 200    # milliseconds
-    print("Warn: take default Config.radarIMGinterval:             \t'%s'"
-          % Config.radarIMGinterval)
-
-try:
-    Config.radarSETinterval
-except AttributeError:
-    Config.radarSETinterval = 5    # 5 times radarIMGinterval
-    print("Warn: take default Config.radarSETinterval:             \t'%s'"
-          % Config.radarSETinterval)
 
 try:
     Config.fontattr
@@ -1095,6 +1097,54 @@ try:
 except AttributeError:
     Config.useslideshow = 0
 
+try:
+    Config.LtopDateformat
+except AttributeError:
+    Config.LtopDateformat = "{0:%A %B} {0.day}<sup>{1}</sup> {0.year}"
+    print("Warn: take default Config.LtopDateformat:        \t'%s'"
+          % Config.LtopDateformat)
+
+try:
+    Config.LtopDateformat2
+except AttributeError:
+    Config.LtopDateformat2 = "{0:%a %b} {0.day}<sup>{1}</sup> {0.year}"
+    print("Warn: take default Config.LtopDateformat2:       \t'%s'"
+          % Config.LtopDateformat)
+
+try:
+    Config.Ltimeformat
+except AttributeError:
+    Config.Ltimeformat = "{0:%I:%M %p}"
+    print("Warn: take default Config.Ltimeformat:           \t'%s'"
+          % Config.Ltimeformat)
+
+try:
+    Config.Ltimestampformat
+except AttributeError:
+    Config.Ltimestampformat = "{0:%I:%M %p}"
+    print("Warn: take default Config.Ltimestampformat:      \t'%s'"
+          % Config.Ltimestampformat)
+
+try:
+    Config.Ltimesunformat
+except AttributeError:
+    Config.Ltimesunformat = "{0:%I:%M %p}"
+    print("Warn: take default Config.Ltimesunformat:        \t'%s'"
+          % Config.Ltimesunformat)
+
+try:
+    Config.Lforecastdayformat
+except AttributeError:
+    Config.Lforecastdayformat = "{0:%A}"
+    print("Warn: take default Config.Lforecastdayformat:     \t'%s'"
+          % Config.Lforecastdayformat)
+
+try:
+    Config.Lforecastdaytimeformat
+except AttributeError:
+    Config.Lforecastdaytimeformat = "{0:%I:%M %p}"
+    print("Warn: take default Config.Lforecastdaytimeformat: \t'%s'"
+          % Config.Lforecastdaytimeformat)
 
 #
 # Check if Mapbox API key is set, and use mapbox if so
@@ -1114,6 +1164,18 @@ lastkeytime = 0
 lastapiget = time.time()
 
 app = QtGui.QApplication(sys.argv)
+
+# /BL fix #141 START Config.DateLocale does not format forecast date and time
+if Config.DateLocale != "":
+    try:
+        locale.setlocale(locale.LC_TIME, Config.DateLocale)
+    except Exception as e:
+        print("Error: (setlocale.LC_TIME, '%s') fails, reason: %s"
+              % (Config.DateLocale, e))
+        Config.DateLocale = ""
+        pass
+# /BL fix #141 END
+
 desktop = app.desktop()
 rec = desktop.screenGeometry()
 height = rec.height()
@@ -1484,7 +1546,7 @@ for i in range(0, 9):
                       "}")
     lab.setGeometry(1137 * xscale, i * 100 * yscale,
                     300 * xscale, 100 * yscale)
-    
+
     icon = QtGui.QLabel(lab)
     icon.setStyleSheet("#icon { background-color: transparent; }")
     icon.setGeometry(0, 0, 100 * xscale, 100 * yscale)


### PR DESCRIPTION
Fix #122 "does not work with regional settings"

Fix part of #125 "Text layout issues":
1. Put all date/time format strings in the config (with appropriate defaults in the startup area so old configs still work)

Fix #141 "Config.DateLocale does not format forecast date and time"

Made some records in Config-Example.py shorter than 80 chars.
