### PR TITLE
Radar fixes, bug fixes, update config examples, PEP8 cleanup, etc.

### DIFF
--- a/Clock/Config-Example-Bedside.py
+++ b/Clock/Config-Example-Bedside.py
@@ -1,15 +1,18 @@
-from GoogleMercatorProjection import LatLng
+# -*- coding: utf-8 -*-
 from PyQt4.QtGui import QColor
 
+from GoogleMercatorProjection import LatLng
+
 # LOCATION(S)
-# Further radar configuration (zoom, marker location)
-#  can be completed under the RADAR section
+# Further radar configuration (zoom, marker location) can be
+# completed under the RADAR section
 primary_coordinates = 44.9764016, -93.2486732  # Change to your Lat/Lon
 
 # Location for weather report
 location = LatLng(primary_coordinates[0], primary_coordinates[1])
 # Default radar location
-primary_location = LatLng(primary_coordinates[0], primary_coordinates[1])
+radar_location = LatLng(primary_coordinates[0], primary_coordinates[1])
+
 noaastream = 'http://www.urberg.net:8000/tim273/edina'
 background = 'images/bb.jpg'
 squares1 = 'images/squares1-green.png'
@@ -21,129 +24,200 @@ hourhand = 'images/hourhand-darkgreen.png'
 minhand = 'images/minhand-darkgreen.png'
 sechand = 'images/sechand-darkgreen.png'
 
-digital = 0             # 1 = Digtal Clock, 0 = Analog Clock
+# SlideShow
+useslideshow = 0  # 1 to enable, 0 to disable
+slide_time = 305  # in seconds, 3600 per hour
+slides = 'images/slideshow'  # the path to your local images
+slide_bg_color = '#000'  # https://htmlcolorcodes.com/  black #000
 
-digitalcolor = "#154018"
-digitalformat = "{0:%I:%M\n%S %p}"  # The format of the time
+digital = 0  # 1 = Digtal Clock, 0 = Analog Clock
+
+# Goes with dark green config
+digitalcolor = '#154018'
+digitalformat = '{0:%I:%M\n%S %p}'  # Format of the digital clock face
 digitalsize = 200
+
 # The above example shows in this way:
 #  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v1.jpg
-# ( specifications of the time string are documented here:
-#  https://docs.python.org/2/library/time.html#time.strftime )
+# (specifications of the time string are documented here:
+#  https://docs.python.org/2/library/time.html#time.strftime)
 
-# digitalformat = "{0:%I:%M}"
+# digitalformat = '{0:%I:%M}'
 # digitalsize = 250
-# The above example shows in this way:
+#  The above example shows in this way:
 #  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v2.jpg
 
+digitalformat2 = '{0:%H:%M:%S}'  # Format of the digital time on second screen
 
-# 0 = English, 1 = Metric
-metric = 0
+clockUTC = 0  # Clock (analog/digital/top date) to display in UTC regardless of PiOS timezone
 
-# minutes
-radar_refresh = 10
-
-# minutes
-weather_refresh = 30
-
+metric = 0  # 0 = English, 1 = Metric
+radar_refresh = 10  # minutes
+weather_refresh = 30  # minutes
 # Wind in degrees instead of cardinal 0 = cardinal, 1 = degrees
 wind_degrees = 0
 
-# Font attribute applied globally
-fontattr = 'font-weight: bold; '
+# gives all text additional attributes using QT style notation
+# example: fontattr = 'font-weight: bold; '
+fontattr = ''
 
 # These are to dim the radar images, if needed.
 dimcolor = QColor('#103125')
 dimcolor.setAlpha(192)
 
+# Optional Current conditions replaced with observations from a METAR station
+# METAR is worldwide, provided mostly for pilots
+# But data can be sparse outside US and Europe
+# If you're close to an international airport, you should find something close
+# Find the closest METAR station with the following URL
+# https://www.aviationweather.gov/metar
+# scroll/zoom the map to find your closest station
+# or look up the ICAO code here:
+# https://airportcodes.aero/name
+METAR = ''
+
 # Language Specific wording
-# DarkSky Language code
-#  (https://darksky.net/dev/docs under lang=)
-Language = "EN"
+# OpenWeather Language code
+#  (https://openweathermap.org/current#multi)
+Language = 'EN'
 
 # The Python Locale for date/time (locale.setlocale)
 #  '' for default Pi Setting
-# Locales must be installed in your Pi.. to check what is installed
+# Locales must be installed in your Pi... to check what is installed
 # locale -a
 # to install locales
 # sudo dpkg-reconfigure locales
 DateLocale = ''
 
 # Language specific wording
-LPressure = "Pressure "
-LHumidity = "Humidity "
-LWind = "Wind "
-Lgusting = " gusting "
-LFeelslike = "Feels like "
-LPrecip1hr = " Precip 1hr:"
-LToday = "Today: "
-LSunRise = "Sun Rise:"
-LSet = " Set: "
-LMoonPhase = " Moon Phase:"
-LInsideTemp = "Inside Temp "
-LRain = " Rain: "
-LSnow = " Snow: "
+LPressure = 'Pressure '
+LHumidity = 'Humidity '
+LWind = 'Wind '
+Lgusting = ' gust '
+LFeelslike = 'Feels like '
+LPrecip1hr = ' Precip 1hr: '
+LToday = 'Today: '
+LSunRise = 'Sun Rise: '
+LSet = ' Set: '
+LMoonPhase = ' Moon: '
+LInsideTemp = 'Inside Temp '
+LRain = ' Rain: '
+LSnow = ' Snow: '
+Lmoon1 = 'New Moon'
+Lmoon2 = 'Waxing Crescent'
+Lmoon3 = 'First Quarter'
+Lmoon4 = 'Waxing Gibbous'
+Lmoon5 = 'Full Moon'
+Lmoon6 = 'Waning Gibbous'
+Lmoon7 = 'Third Quarter'
+Lmoon8 = 'Waning Crescent'
 
+# Language specific terms for Tomorrow.io weather conditions
+Ltm_code_map = {
+    0: 'Unknown',
+    1000: 'Clear',
+    1100: 'Mostly Clear',
+    1101: 'Partly Cloudy',
+    1102: 'Mostly Cloudy',
+    1001: 'Cloudy',
+    2000: 'Fog',
+    2100: 'Light Fog',
+    4000: 'Drizzle',
+    4001: 'Rain',
+    4200: 'Light Rain',
+    4201: 'Heavy Rain',
+    5000: 'Snow',
+    5001: 'Flurries',
+    5100: 'Light Snow',
+    5101: 'Heavy Snow',
+    6000: 'Freezing Drizzle',
+    6001: 'Freezing Rain',
+    6200: 'Light Freezing Rain',
+    6201: 'Heavy Freezing Rain',
+    7000: 'Ice Pellets',
+    7101: 'Heavy Ice Pellets',
+    7102: 'Light Ice Pellets',
+    8000: 'Thunderstorm'
+}
 
 # RADAR
-# By default, primary_location entered will be the center and marker of all
-# radar images.
+# By default, radar_location entered will be the
+# center and marker of all radar images.
 # To update centers/markers, change radar sections
 # below the desired lat/lon as:
 # -FROM-
-# primary_location,
+# radar_location,
 # -TO-
 # LatLng(44.9764016,-93.2486732),
 radar1 = {
-    'center': primary_location,  # the center of your radar block
-    'zoom': 7,  # this is a google maps zoom factor, bigger = smaller area
-    'style': 'mapbox/cj5l80zrp29942rmtg0zctjto',  # Mapbox calls this Decimal
-    'markers': (   # google maps markers can be overlayed
+    'center': radar_location,  # the center of your radar block
+    'zoom': 7,  # this is a maps zoom factor, bigger = smaller area
+    'style': 'mapbox/cj5l80zrp29942rmtg0zctjto',  # Mapbox calls this map style 'Decimal'
+    'color': 6,  # rainviewer radar color style:
+    # https://www.rainviewer.com/api.html#colorSchemes
+    'smooth': 1,  # rainviewer radar smoothing
+    'snow': 1,  # rainviewer radar show snow as different color
+    'markers': (  # google maps markers can be overlaid
         {
-            'location': primary_location,
+            'visible': 1,  # 0 = hide marker, 1 = show marker
+            'location': radar_location,
             'color': 'red',
             'size': 'small',
-        },          # dangling comma is on purpose.
+            'image': 'teardrop-dot',  # optional image from the markers folder
+        },  # dangling comma is on purpose.
     )
 }
 
-
 radar2 = {
-    'center': primary_location,
+    'center': radar_location,
     'zoom': 11,
-    'style': 'mapbox/cj5l80zrp29942rmtg0zctjto',  # Mapbox calls this Decimal
+    'style': 'mapbox/cj5l80zrp29942rmtg0zctjto',
+    'color': 6,
+    'smooth': 1,
+    'snow': 1,
     'markers': (
         {
-            'location': primary_location,
+            'visible': 1,
+            'location': radar_location,
             'color': 'red',
             'size': 'small',
+            'image': 'teardrop-dot',
         },
     )
 }
 
-
 radar3 = {
-    'center': primary_location,
+    'center': radar_location,
     'zoom': 7,
-    'style': 'mapbox/cj5l80zrp29942rmtg0zctjto',  # Mapbox calls this Decimal
+    'style': 'mapbox/cj5l80zrp29942rmtg0zctjto',
+    'color': 6,
+    'smooth': 1,
+    'snow': 1,
     'markers': (
         {
-            'location': primary_location,
+            'visible': 1,
+            'location': radar_location,
             'color': 'red',
             'size': 'small',
+            'image': 'teardrop-dot',
         },
     )
 }
 
 radar4 = {
-    'center': primary_location,
+    'center': radar_location,
     'zoom': 11,
-    'style': 'mapbox/cj5l80zrp29942rmtg0zctjto',  # Mapbox calls this Decimal
+    'style': 'mapbox/cj5l80zrp29942rmtg0zctjto',
+    'color': 6,
+    'smooth': 1,
+    'snow': 1,
     'markers': (
         {
-            'location': primary_location,
+            'visible': 1,
+            'location': radar_location,
             'color': 'red',
             'size': 'small',
+            'image': 'teardrop-dot',
         },
     )
 }

--- a/Clock/Config-Example-Berlin.py
+++ b/Clock/Config-Example-Berlin.py
@@ -1,14 +1,18 @@
 # -*- coding: utf-8 -*-
-from GoogleMercatorProjection import LatLng
 from PyQt4.QtGui import QColor
+
+from GoogleMercatorProjection import LatLng
 
 # LOCATION(S)
 # Further radar configuration (zoom, marker location) can be
 # completed under the RADAR section
 primary_coordinates = 52.5074559, 13.144557  # Change to your Lat/Lon
 
+# Location for weather report
 location = LatLng(primary_coordinates[0], primary_coordinates[1])
-primary_location = LatLng(primary_coordinates[0], primary_coordinates[1])
+# Default radar location
+radar_location = LatLng(primary_coordinates[0], primary_coordinates[1])
+
 noaastream = ''
 background = 'images/berlin-at-night-mrwallpaper.jpg'
 squares1 = 'images/squares1-kevin.png'
@@ -20,30 +24,38 @@ hourhand = 'images/hourhand.png'
 minhand = 'images/minhand.png'
 sechand = 'images/sechand.png'
 
+# SlideShow
+useslideshow = 0  # 1 to enable, 0 to disable
+slide_time = 305  # in seconds, 3600 per hour
+slides = 'images/slideshow'  # the path to your local images
+slide_bg_color = '#000'  # https://htmlcolorcodes.com/  black #000
 
-digital = 0             # 1 = Digtal Clock, 0 = Analog Clock
+digital = 0  # 1 = Digtal Clock, 0 = Analog Clock
 
 # Goes with light blue config (like the default one)
-digitalcolor = "#50CBEB"
-digitalformat = "{0:%I:%M\n%S %p}"  # The format of the time
+digitalcolor = '#50CBEB'
+digitalformat = '{0:%I:%M\n%S %p}'  # Format of the digital clock face
 digitalsize = 200
+
 # The above example shows in this way:
 #  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v1.jpg
-# ( specifications of the time string are documented here:
-#  https://docs.python.org/2/library/time.html#time.strftime )
+# (specifications of the time string are documented here:
+#  https://docs.python.org/2/library/time.html#time.strftime)
 
-# digitalformat = "{0:%I:%M}"
+# digitalformat = '{0:%I:%M}'
 # digitalsize = 250
 #  The above example shows in this way:
 #  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v2.jpg
 
+digitalformat2 = '{0:%H:%M:%S}'  # Format of the digital time on second screen
+
+clockUTC = 0  # Clock (analog/digital/top date) to display in UTC regardless of PiOS timezone
 
 metric = 1  # 0 = English, 1 = Metric
-radar_refresh = 10      # minutes
-weather_refresh = 30    # minutes
+radar_refresh = 10  # minutes
+weather_refresh = 30  # minutes
 # Wind in degrees instead of cardinal 0 = cardinal, 1 = degrees
 wind_degrees = 0
-
 
 # gives all text additional attributes using QT style notation
 # example: fontattr = 'font-weight: bold; '
@@ -54,16 +66,25 @@ fontattr = ''
 dimcolor = QColor('#000000')
 dimcolor.setAlpha(0)
 
-METAR=""
+# Optional Current conditions replaced with observations from a METAR station
+# METAR is worldwide, provided mostly for pilots
+# But data can be sparse outside US and Europe
+# If you're close to an international airport, you should find something close
+# Find the closest METAR station with the following URL
+# https://www.aviationweather.gov/metar
+# scroll/zoom the map to find your closest station
+# or look up the ICAO code here:
+# https://airportcodes.aero/name
+METAR = ''
 
 # Language Specific wording
-# OpenWeatherMap Language code
+# OpenWeather Language code
 #  (https://openweathermap.org/current#multi)
-Language = "DE"
+Language = 'DE'
 
 # The Python Locale for date/time (locale.setlocale)
 #  '' for default Pi Setting
-# Locales must be installed in your Pi.. to check what is installed
+# Locales must be installed in your Pi... to check what is installed
 # locale -a
 # to install locales
 # sudo dpkg-reconfigure locales
@@ -71,33 +92,32 @@ DateLocale = 'de_DE.utf-8'
 
 # Language specific wording
 # thanks to colonia27 for the language work
-LPressure = "Luftdruck "
-LHumidity = "Feuchtigkeit "
-LWind = "Wind "
-Lgusting = u" böen "
-LFeelslike = u"Gefühlt "
-LPrecip1hr = " Niederschlag 1h:"
-LToday = "Heute: "
-LSunRise = "Sonnenaufgang:"
-LSet = " unter: "
-LMoonPhase = " Mond Phase:"
-LInsideTemp = "Innen Temp "
-LRain = " Regen: "
-LSnow = " Schnee: "
+LPressure = 'Luftdruck '
+LHumidity = 'Feuchtigkeit '
+LWind = 'Wind '
+Lgusting = u' böen '
+LFeelslike = u'Gefühlt '
+LPrecip1hr = ' Niederschlag 1h:'
+LToday = 'Heute: '
+LSunRise = 'Sonnenaufgang:'
+LSet = ' unter:'
+LMoonPhase = ' Mond Phase:'
+LInsideTemp = 'Innen Temp '
+LRain = ' Regen: '
+LSnow = ' Schnee: '
 Lmoon1 = 'Neumond'
 Lmoon2 = 'Zunehmender Sichelmond'
 Lmoon3 = 'Zunehmender Halbmond'
 Lmoon4 = 'Zunehmender Dreiviertelmond'
-Lmoon5 = 'Vollmond '
+Lmoon5 = 'Vollmond'
 Lmoon6 = 'Abnehmender Dreiviertelmond'
 Lmoon7 = 'Abnehmender Halbmond'
 Lmoon8 = 'Abnehmender Sichelmond'
-# Language Specific terms for weather conditions
 
-
+# Language specific terms for Tomorrow.io weather conditions
 Ltm_code_map = {
     0: 'Unknown',
-    1000: "Klar",
+    1000: 'Klar',
     1100: 'Teilweise klar',
     1101: 'Teilweise Wolkig',
     1102: 'Meist Wolkig',
@@ -122,62 +142,84 @@ Ltm_code_map = {
     8000: 'Gewitter'
 }
 
-
 # RADAR
-# By default, primary_location entered will be the
-#  center and marker of all radar images.
+# By default, radar_location entered will be the
+# center and marker of all radar images.
 # To update centers/markers, change radar sections
 # below the desired lat/lon as:
 # -FROM-
-# primary_location,
+# radar_location,
 # -TO-
 # LatLng(44.9764016,-93.2486732),
 radar1 = {
-    'center': primary_location,  # the center of your radar block
-    'zoom': 7,  # this is a google maps zoom factor, bigger = smaller area
-    'markers': (   # google maps markers can be overlayed
+    'center': radar_location,  # the center of your radar block
+    'zoom': 7,  # this is a maps zoom factor, bigger = smaller area
+    'style': 'mapbox/satellite-streets-v12',  # optional style (mapbox only)
+    'color': 6,  # rainviewer radar color style:
+    # https://www.rainviewer.com/api.html#colorSchemes
+    'smooth': 1,  # rainviewer radar smoothing
+    'snow': 1,  # rainviewer radar show snow as different color
+    'markers': (  # google maps markers can be overlaid
         {
-            'location': primary_location,
+            'visible': 1,  # 0 = hide marker, 1 = show marker
+            'location': radar_location,
             'color': 'red',
             'size': 'small',
-        },          # dangling comma is on purpose.
+            'image': 'teardrop-dot',  # optional image from the markers folder
+        },  # dangling comma is on purpose.
     )
 }
 
-
 radar2 = {
-    'center': primary_location,
+    'center': radar_location,
     'zoom': 11,
+    'style': 'mapbox/satellite-streets-v12',
+    'color': 6,
+    'smooth': 1,
+    'snow': 1,
     'markers': (
         {
-            'location': primary_location,
+            'visible': 1,
+            'location': radar_location,
             'color': 'red',
             'size': 'small',
+            'image': 'teardrop-dot',
         },
     )
 }
 
-
 radar3 = {
-    'center': primary_location,
+    'center': radar_location,
     'zoom': 7,
+    'style': 'mapbox/satellite-streets-v12',
+    'color': 6,
+    'smooth': 1,
+    'snow': 1,
     'markers': (
         {
-            'location': primary_location,
+            'visible': 1,
+            'location': radar_location,
             'color': 'red',
             'size': 'small',
+            'image': 'teardrop-dot',
         },
     )
 }
 
 radar4 = {
-    'center': primary_location,
+    'center': radar_location,
     'zoom': 11,
+    'style': 'mapbox/satellite-streets-v12',
+    'color': 6,
+    'smooth': 1,
+    'snow': 1,
     'markers': (
         {
-            'location': primary_location,
+            'visible': 1,
+            'location': radar_location,
             'color': 'red',
             'size': 'small',
+            'image': 'teardrop-dot',
         },
     )
 }

--- a/Clock/Config-Example-London.py
+++ b/Clock/Config-Example-London.py
@@ -1,15 +1,19 @@
-from GoogleMercatorProjection import LatLng     # NOQA
+# -*- coding: utf-8 -*-
 from PyQt4.QtGui import QColor
 
+from GoogleMercatorProjection import LatLng
 
 # LOCATION(S)
 # Further radar configuration (zoom, marker location) can be
 # completed under the RADAR section
 primary_coordinates = 51.5286416, -0.1015987  # Change to your Lat/Lon
 
+# Location for weather report
 location = LatLng(primary_coordinates[0], primary_coordinates[1])
-primary_location = LatLng(primary_coordinates[0], primary_coordinates[1])
-noaastream = '???'
+# Default radar location
+radar_location = LatLng(primary_coordinates[0], primary_coordinates[1])
+
+noaastream = ''
 background = 'images/london-at-night-wallpapers.jpg'
 squares1 = 'images/squares1-kevin.png'
 squares2 = 'images/squares2-kevin.png'
@@ -20,27 +24,36 @@ hourhand = 'images/hourhand.png'
 minhand = 'images/minhand.png'
 sechand = 'images/sechand.png'
 
+# SlideShow
+useslideshow = 0  # 1 to enable, 0 to disable
+slide_time = 305  # in seconds, 3600 per hour
+slides = 'images/slideshow'  # the path to your local images
+slide_bg_color = '#000'  # https://htmlcolorcodes.com/  black #000
 
-digital = 0             # 1 = Digtal Clock, 0 = Analog Clock
+digital = 0  # 1 = Digtal Clock, 0 = Analog Clock
 
 # Goes with light blue config (like the default one)
-digitalcolor = "#50CBEB"
-digitalformat = "{0:%I:%M\n%S %p}"  # The format of the time
+digitalcolor = '#50CBEB'
+digitalformat = '{0:%I:%M\n%S %p}'  # Format of the digital clock face
 digitalsize = 200
+
 # The above example shows in this way:
 #  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v1.jpg
-# ( specifications of the time string are documented here:
-#  https://docs.python.org/2/library/time.html#time.strftime )
+# (specifications of the time string are documented here:
+#  https://docs.python.org/2/library/time.html#time.strftime)
 
-# digitalformat = "{0:%I:%M}"
+# digitalformat = '{0:%I:%M}'
 # digitalsize = 250
 #  The above example shows in this way:
 #  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v2.jpg
 
+digitalformat2 = '{0:%H:%M:%S}'  # Format of the digital time on second screen
+
+clockUTC = 0  # Clock (analog/digital/top date) to display in UTC regardless of PiOS timezone
 
 metric = 1  # 0 = English, 1 = Metric
-radar_refresh = 10      # minutes
-weather_refresh = 30    # minutes
+radar_refresh = 10  # minutes
+weather_refresh = 30  # minutes
 # Wind in degrees instead of cardinal 0 = cardinal, 1 = degrees
 wind_degrees = 0
 
@@ -53,91 +66,159 @@ fontattr = ''
 dimcolor = QColor('#000000')
 dimcolor.setAlpha(0)
 
-METAR="EGLL"  # LHR London Heathrow Airport
+# Optional Current conditions replaced with observations from a METAR station
+# METAR is worldwide, provided mostly for pilots
+# But data can be sparse outside US and Europe
+# If you're close to an international airport, you should find something close
+# Find the closest METAR station with the following URL
+# https://www.aviationweather.gov/metar
+# scroll/zoom the map to find your closest station
+# or look up the ICAO code here:
+# https://airportcodes.aero/name
+METAR = 'EGLL'  # LHR London Heathrow Airport
 
 # Language Specific wording
-# DarkSky Language code
-#  (https://darksky.net/dev/docs under lang=)
-Language = "EN"
+# OpenWeather Language code
+#  (https://openweathermap.org/current#multi)
+Language = 'EN'
 
 # The Python Locale for date/time (locale.setlocale)
 #  '' for default Pi Setting
-# Locales must be installed in your Pi.. to check what is installed
+# Locales must be installed in your Pi... to check what is installed
 # locale -a
 # to install locales
 # sudo dpkg-reconfigure locales
 DateLocale = ''
 
 # Language specific wording
-LPressure = "Pressure "
-LHumidity = "Humidity "
-LWind = "Wind "
-Lgusting = " gusting "
-LFeelslike = "Feels like "
-LPrecip1hr = " Precip 1hr:"
-LToday = "Today: "
-LSunRise = "Sun Rise:"
-LSet = " Set: "
-LMoonPhase = " Moon Phase:"
-LInsideTemp = "Inside Temp "
-LRain = " Rain: "
-LSnow = " Snow: "
+LPressure = 'Pressure '
+LHumidity = 'Humidity '
+LWind = 'Wind '
+Lgusting = ' gust '
+LFeelslike = 'Feels like '
+LPrecip1hr = ' Precip 1hr: '
+LToday = 'Today: '
+LSunRise = 'Sun Rise: '
+LSet = ' Set: '
+LMoonPhase = ' Moon: '
+LInsideTemp = 'Inside Temp '
+LRain = ' Rain: '
+LSnow = ' Snow: '
+Lmoon1 = 'New Moon'
+Lmoon2 = 'Waxing Crescent'
+Lmoon3 = 'First Quarter'
+Lmoon4 = 'Waxing Gibbous'
+Lmoon5 = 'Full Moon'
+Lmoon6 = 'Waning Gibbous'
+Lmoon7 = 'Third Quarter'
+Lmoon8 = 'Waning Crescent'
 
+# Language specific terms for Tomorrow.io weather conditions
+Ltm_code_map = {
+    0: 'Unknown',
+    1000: 'Clear',
+    1100: 'Mostly Clear',
+    1101: 'Partly Cloudy',
+    1102: 'Mostly Cloudy',
+    1001: 'Cloudy',
+    2000: 'Fog',
+    2100: 'Light Fog',
+    4000: 'Drizzle',
+    4001: 'Rain',
+    4200: 'Light Rain',
+    4201: 'Heavy Rain',
+    5000: 'Snow',
+    5001: 'Flurries',
+    5100: 'Light Snow',
+    5101: 'Heavy Snow',
+    6000: 'Freezing Drizzle',
+    6001: 'Freezing Rain',
+    6200: 'Light Freezing Rain',
+    6201: 'Heavy Freezing Rain',
+    7000: 'Ice Pellets',
+    7101: 'Heavy Ice Pellets',
+    7102: 'Light Ice Pellets',
+    8000: 'Thunderstorm'
+}
 
 # RADAR
-# By default, primary_location entered will be the
-#  center and marker of all radar images.
-# To update centers/markers,change radar sections below the desired lat/lon as:
+# By default, radar_location entered will be the
+# center and marker of all radar images.
+# To update centers/markers, change radar sections
+# below the desired lat/lon as:
 # -FROM-
-# primary_location,
+# radar_location,
 # -TO-
 # LatLng(44.9764016,-93.2486732),
 radar1 = {
-    'center': primary_location,  # the center of your radar block
-    'zoom': 7,  # this is a google maps zoom factor, bigger = smaller area
-    'markers': (   # google maps markers can be overlayed
+    'center': radar_location,  # the center of your radar block
+    'zoom': 7,  # this is a maps zoom factor, bigger = smaller area
+    'style': 'mapbox/satellite-streets-v12',  # optional style (mapbox only)
+    'color': 6,  # rainviewer radar color style:
+    # https://www.rainviewer.com/api.html#colorSchemes
+    'smooth': 1,  # rainviewer radar smoothing
+    'snow': 1,  # rainviewer radar show snow as different color
+    'markers': (  # google maps markers can be overlaid
         {
-            'location': primary_location,
+            'visible': 1,  # 0 = hide marker, 1 = show marker
+            'location': radar_location,
             'color': 'red',
             'size': 'small',
-        },          # dangling comma is on purpose.
+            'image': 'teardrop-dot',  # optional image from the markers folder
+        },  # dangling comma is on purpose.
     )
 }
 
-
 radar2 = {
-    'center': primary_location,
+    'center': radar_location,
     'zoom': 11,
+    'style': 'mapbox/satellite-streets-v12',
+    'color': 6,
+    'smooth': 1,
+    'snow': 1,
     'markers': (
         {
-            'location': primary_location,
+            'visible': 1,
+            'location': radar_location,
             'color': 'red',
             'size': 'small',
+            'image': 'teardrop-dot',
         },
     )
 }
 
-
 radar3 = {
-    'center': primary_location,
+    'center': radar_location,
     'zoom': 7,
+    'style': 'mapbox/satellite-streets-v12',
+    'color': 6,
+    'smooth': 1,
+    'snow': 1,
     'markers': (
         {
-            'location': primary_location,
+            'visible': 1,
+            'location': radar_location,
             'color': 'red',
             'size': 'small',
+            'image': 'teardrop-dot',
         },
     )
 }
 
 radar4 = {
-    'center': primary_location,
+    'center': radar_location,
     'zoom': 11,
+    'style': 'mapbox/satellite-streets-v12',
+    'color': 6,
+    'smooth': 1,
+    'snow': 1,
     'markers': (
         {
-            'location': primary_location,
+            'visible': 1,
+            'location': radar_location,
             'color': 'red',
             'size': 'small',
+            'image': 'teardrop-dot',
         },
     )
 }

--- a/Clock/Config-Example.py
+++ b/Clock/Config-Example.py
@@ -1,14 +1,18 @@
-from GoogleMercatorProjection import LatLng
+# -*- coding: utf-8 -*-
 from PyQt4.QtGui import QColor
 
+from GoogleMercatorProjection import LatLng
 
 # LOCATION(S)
 # Further radar configuration (zoom, marker location) can be
 # completed under the RADAR section
 primary_coordinates = 44.9764016, -93.2486732  # Change to your Lat/Lon
 
+# Location for weather report
 location = LatLng(primary_coordinates[0], primary_coordinates[1])
-primary_location = LatLng(primary_coordinates[0], primary_coordinates[1])
+# Default radar location
+radar_location = LatLng(primary_coordinates[0], primary_coordinates[1])
+
 noaastream = 'http://www.urberg.net:8000/tim273/edina'
 background = 'images/clockbackground-kevin.png'
 squares1 = 'images/squares1-kevin.png'
@@ -21,36 +25,35 @@ minhand = 'images/minhand.png'
 sechand = 'images/sechand.png'
 
 # SlideShow
-useslideshow = 0             # 1 to enable, 0 to disable
-slide_time = 305              # in seconds, 3600 per hour
-slides = 'images/slideshow'   # the path to your local images
-slide_bg_color = "#000"       # https://htmlcolorcodes.com/  black #000
+useslideshow = 0  # 1 to enable, 0 to disable
+slide_time = 305  # in seconds, 3600 per hour
+slides = 'images/slideshow'  # the path to your local images
+slide_bg_color = '#000'  # https://htmlcolorcodes.com/  black #000
 
-digital = 0                 # 1 = Digtal Clock, 0 = Analog Clock
+digital = 0  # 1 = Digtal Clock, 0 = Analog Clock
 
 # Goes with light blue config (like the default one)
-digitalcolor = "#50CBEB"
-digitalformat = "{0:%I:%M\n%S %p}"  # Format of the digital clock face
+digitalcolor = '#50CBEB'
+digitalformat = '{0:%I:%M\n%S %p}'  # Format of the digital clock face
 digitalsize = 200
 
 # The above example shows in this way:
 #  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v1.jpg
-# ( specifications of the time string are documented here:
-#  https://docs.python.org/2/library/time.html#time.strftime )
+# (specifications of the time string are documented here:
+#  https://docs.python.org/2/library/time.html#time.strftime)
 
-# digitalformat = "{0:%I:%M}"
+# digitalformat = '{0:%I:%M}'
 # digitalsize = 250
 #  The above example shows in this way:
 #  https://github.com/n0bel/PiClock/blob/master/Documentation/Digital%20Clock%20v2.jpg
 
-digitalformat2 = "{0:%H:%M:%S}"  # Format of the digital time on second screen
+digitalformat2 = '{0:%H:%M:%S}'  # Format of the digital time on second screen
 
-clockUTC = 0 # Clock (analog/digital/top date) to display in UTC regardless of PiOS timezone
+clockUTC = 0  # Clock (analog/digital/top date) to display in UTC regardless of PiOS timezone
 
-usemapbox = 0   # Use Mapbox.com for maps, needs api key (mbapi in ApiKeys.py)
 metric = 0  # 0 = English, 1 = Metric
-radar_refresh = 10      # minutes
-weather_refresh = 30    # minutes
+radar_refresh = 10  # minutes
+weather_refresh = 30  # minutes
 # Wind in degrees instead of cardinal 0 = cardinal, 1 = degrees
 wind_degrees = 0
 
@@ -64,9 +67,9 @@ dimcolor = QColor('#000000')
 dimcolor.setAlpha(0)
 
 # Optional Current conditions replaced with observations from a METAR station
-# METAR is world wide, provided mostly for pilots
+# METAR is worldwide, provided mostly for pilots
 # But data can be sparse outside US and Europe
-#  If you're close to an international airport, you should find soemthing close
+# If you're close to an international airport, you should find something close
 # Find the closest METAR station with the following URL
 # https://www.aviationweather.gov/metar
 # scroll/zoom the map to find your closest station
@@ -75,32 +78,32 @@ dimcolor.setAlpha(0)
 METAR = ''
 
 # Language Specific wording
-# DarkSky Language code
-#  (https://darksky.net/dev/docs under lang=)
-Language = "EN"
+# OpenWeather Language code
+#  (https://openweathermap.org/current#multi)
+Language = 'EN'
 
 # The Python Locale for date/time (locale.setlocale)
 #  '' for default Pi Setting
-# Locales must be installed in your Pi.. to check what is installed
+# Locales must be installed in your Pi... to check what is installed
 # locale -a
 # to install locales
 # sudo dpkg-reconfigure locales
 DateLocale = ''
 
 # Language specific wording
-LPressure = "Pressure "
-LHumidity = "Humidity "
-LWind = "Wind "
-Lgusting = " gust "
-LFeelslike = "Feels like "
-LPrecip1hr = " Precip 1hr: "
-LToday = "Today: "
-LSunRise = "Sun Rise: "
-LSet = " Set: "
-LMoonPhase = " Moon: "
-LInsideTemp = "Inside Temp "
-LRain = " Rain: "
-LSnow = " Snow: "
+LPressure = 'Pressure '
+LHumidity = 'Humidity '
+LWind = 'Wind '
+Lgusting = ' gust '
+LFeelslike = 'Feels like '
+LPrecip1hr = ' Precip 1hr: '
+LToday = 'Today: '
+LSunRise = 'Sun Rise: '
+LSet = ' Set: '
+LMoonPhase = ' Moon: '
+LInsideTemp = 'Inside Temp '
+LRain = ' Rain: '
+LSnow = ' Snow: '
 Lmoon1 = 'New Moon'
 Lmoon2 = 'Waxing Crescent'
 Lmoon3 = 'First Quarter'
@@ -108,74 +111,75 @@ Lmoon4 = 'Waxing Gibbous'
 Lmoon5 = 'Full Moon'
 Lmoon6 = 'Waning Gibbous'
 Lmoon7 = 'Third Quarter'
-Lmoon8 = 'Waning Crecent'
-# Language Specific terms for weather conditions
-Lcc_code_map = {
-            "freezing_rain_heavy": "Freezing Rain",
-            "freezing_rain": "Freezing Rain",
-            "freezing_rain_light": "Freezing Rain",
-            "freezing_drizzle": "Freezing Drizzle",
-            "ice_pellets_heavy": "Ice Pellets",
-            "ice_pellets": "Ice Pellets",
-            "ice_pellets_light": "Ice Pellets",
-            "snow_heavy": "Heavy Snow",
-            "snow": "Snow",
-            "snow_light": "Light Snow",
-            "flurries": "Flurries",
-            "tstorm": "Thunder Storm",
-            "rain_heavy": "Heavy Rain",
-            "rain": "Rain",
-            "rain_light": "Light Rain",
-            "drizzle": "Drizzle",
-            "fog_light": "Light Fog",
-            "fog": "Fog",
-            "cloudy": "Cloudy",
-            "mostly_cloudy": "Mostly Cloudy",
-            "partly_cloudy": "Partly Cloudy",
-            "mostly_clear": "Mostly Clear",
-            "clear": "Clear"
+Lmoon8 = 'Waning Crescent'
+
+# Language specific terms for Tomorrow.io weather conditions
+Ltm_code_map = {
+    0: 'Unknown',
+    1000: 'Clear',
+    1100: 'Mostly Clear',
+    1101: 'Partly Cloudy',
+    1102: 'Mostly Cloudy',
+    1001: 'Cloudy',
+    2000: 'Fog',
+    2100: 'Light Fog',
+    4000: 'Drizzle',
+    4001: 'Rain',
+    4200: 'Light Rain',
+    4201: 'Heavy Rain',
+    5000: 'Snow',
+    5001: 'Flurries',
+    5100: 'Light Snow',
+    5101: 'Heavy Snow',
+    6000: 'Freezing Drizzle',
+    6001: 'Freezing Rain',
+    6200: 'Light Freezing Rain',
+    6201: 'Heavy Freezing Rain',
+    7000: 'Ice Pellets',
+    7101: 'Heavy Ice Pellets',
+    7102: 'Light Ice Pellets',
+    8000: 'Thunderstorm'
 }
 
 # RADAR
-# By default, primary_location entered will be the
-#  center and marker of all radar images.
+# By default, radar_location entered will be the
+# center and marker of all radar images.
 # To update centers/markers, change radar sections
 # below the desired lat/lon as:
 # -FROM-
-# primary_location,
+# radar_location,
 # -TO-
 # LatLng(44.9764016,-93.2486732),
 radar1 = {
-    'center': primary_location,  # the center of your radar block
+    'center': radar_location,  # the center of your radar block
     'zoom': 7,  # this is a maps zoom factor, bigger = smaller area
-    'style': 'mapbox/satellite-streets-v10',  # optional style (mapbox only)
+    'style': 'mapbox/satellite-streets-v12',  # optional style (mapbox only)
     'color': 6,  # rainviewer radar color style:
-                 # https://www.rainviewer.com/api.html#colorSchemes
+    # https://www.rainviewer.com/api.html#colorSchemes
     'smooth': 1,  # rainviewer radar smoothing
     'snow': 1,  # rainviewer radar show snow as different color
-    'markers': (   # google maps markers can be overlayed
+    'markers': (  # google maps markers can be overlaid
         {
             'visible': 1,  # 0 = hide marker, 1 = show marker
-            'location': primary_location,
+            'location': radar_location,
             'color': 'red',
             'size': 'small',
             'image': 'teardrop-dot',  # optional image from the markers folder
-        },          # dangling comma is on purpose.
+        },  # dangling comma is on purpose.
     )
 }
 
-
 radar2 = {
-    'center': primary_location,
+    'center': radar_location,
     'zoom': 11,
-    'style': 'mapbox/satellite-streets-v10',
+    'style': 'mapbox/satellite-streets-v12',
     'color': 6,
     'smooth': 1,
     'snow': 1,
     'markers': (
         {
             'visible': 1,
-            'location': primary_location,
+            'location': radar_location,
             'color': 'red',
             'size': 'small',
             'image': 'teardrop-dot',
@@ -183,18 +187,17 @@ radar2 = {
     )
 }
 
-
 radar3 = {
-    'center': primary_location,
+    'center': radar_location,
     'zoom': 7,
-    'style': 'mapbox/satellite-streets-v10',
+    'style': 'mapbox/satellite-streets-v12',
     'color': 6,
     'smooth': 1,
     'snow': 1,
     'markers': (
         {
             'visible': 1,
-            'location': primary_location,
+            'location': radar_location,
             'color': 'red',
             'size': 'small',
             'image': 'teardrop-dot',
@@ -203,16 +206,16 @@ radar3 = {
 }
 
 radar4 = {
-    'center': primary_location,
+    'center': radar_location,
     'zoom': 11,
-    'style': 'mapbox/satellite-streets-v10',
+    'style': 'mapbox/satellite-streets-v12',
     'color': 6,
     'smooth': 1,
     'snow': 1,
     'markers': (
         {
             'visible': 1,
-            'location': primary_location,
+            'location': radar_location,
             'color': 'red',
             'size': 'small',
             'image': 'teardrop-dot',


### PR DESCRIPTION
@n0bel Sorry if this is a lot...
Fix noise and ghosting in radar due to image objects created with uninitialized data. fixes #157 fixes #190 fixes #241
Fix typo in radar for RainViewer attribution.
Fix crash with OWM forecast when current time is shortly after midnight and there may not be any forecast available after 6am for the final day.
Replace night weather icons in OWM forecast with day icons.
Change Tomorrow.io pressure from surface level to sea level, and metric units to mbar.
Move setlocale from tick() to qtstart(). fixes #256 fixes #257 
Add missing temperature units to forecast boxes.
Add date to daily forecast boxes. fixes #255 
Change background color for frame2 from blue to black, matching frame1.
Fix typo in Config.py language specific wording from Waning Crecent to Waning Crescent.
Expand attribution label to fit openweathermap.org.
Remove unusual 15 multiplier from Tomorrow.io daily forecast snow precipitation intensity.
Change math.abs() to abs() usage in feels_like() function.
Add missing METAR station name after current weather timestamp when metric is selected.
Remove the suppress_current global variable since it was made redundant by the hasMetar global variable. Use hasMetar in places where suppress_current was necessary.
Fix wind gust imperial units in wxfinished_owm() from kph to mph.
Add Radar instance attribute definitions that were missing from Radar __init__.
Change Radar mapboxurl() and googlemapurl() to static methods.
Remove usemapbox Boolean from Config.py and only set it based on existence of mbapi API key. Before, PiClock would check for both, which conflicted.
Log errors from API calls and allow PiClock to continue without crash.
Update all config examples.
Optimize package imports.
Remove unused variables.
Remove global status from variables that don’t need it.
PEP8 cleanup and other formatting changes.
Many more bug fixes and improvements.